### PR TITLE
feat: Implement Stripe Checkout Session fulfillment in billing service

### DIFF
--- a/.protos-version
+++ b/.protos-version
@@ -2,7 +2,7 @@
 # This file specifies which version of the protos repository to use
 
 # Version tag (e.g., v1.0.0) or branch name (e.g., main)
-#PROTOS_VERSION=1.1.8
+#PROTOS_VERSION=1.1.9
 
 # Branch or tag to checkout (use main for latest)
 PROTOS_COMMIT=main

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ cd packages\protos\protos_weebi\tool
 .\generate_protos.ps1
 ```
 
-**WSL/Bash:**
+**WSL/Bash:** (run from weebi_server root, same pattern as weebi_express)
 ```bash
-cd packages/protos/protos_weebi/tool
-chmod +x generate_protos.sh
-./generate_protos.sh
+chmod +x packages/protos/protos_weebi/tool/generate_protos.sh
+./packages/protos/protos_weebi/tool/generate_protos.sh
 ```
+A sibling `protos` repo (e.g. `git_weebi/protos`) is used automatically when present.
 
 ### Check proto version consistency between projects
 
@@ -57,9 +57,7 @@ chmod +x scripts/check_protos_version.sh
 
 ## generate them
 
-cd packages/protos/protos_weebi/tool
-chmod +x generate_protos.sh
-./generate_protos.sh
+From weebi_server root: see **Generate Dart code from proto files** above (PowerShell or WSL/Bash).
 
 ## test it
 grpcurl -proto packages\protos\proto\weebi_app_service.proto dev.weebicom:443 weebi.weebi_app.service.WeebiAppService/readAppMinimumVersion

--- a/packages/billing_service/lib/src/billing_service_base.dart
+++ b/packages/billing_service/lib/src/billing_service_base.dart
@@ -231,6 +231,7 @@ class BillingService extends BillingServiceBase {
   }
 
   /// Internal: fulfill a license after Stripe payment. Called by RPC (service account) or tests.
+  /// Idempotent: if license already exists (e.g. webhook retry or sync-after-redirect), returns success.
   Future<CreateLicenseResponse> _fulfillLicenseFromStripeInternal(
     String firmId,
     String licenseId,
@@ -255,11 +256,33 @@ class BillingService extends BillingServiceBase {
       referralCode: referralCode ?? '',
       creditAppliedCents: creditAppliedCents,
     );
-    final response = await _doCreateLicense(null, firmId, request);
-    if (stripeCustomerId != null && stripeCustomerId.isNotEmpty) {
-      await _updateStripeCustomerId(firmId, stripeCustomerId);
+    try {
+      final response = await _doCreateLicense(null, firmId, request);
+      if (stripeCustomerId != null && stripeCustomerId.isNotEmpty) {
+        await _updateStripeCustomerId(firmId, stripeCustomerId);
+      }
+      return response;
+    } on GrpcError catch (e) {
+      if (e.code == StatusCode.alreadyExists) {
+        // Webhook retry or user-triggered sync: license already created.
+        if (stripeCustomerId != null && stripeCustomerId.isNotEmpty) {
+          await _updateStripeCustomerId(firmId, stripeCustomerId);
+        }
+        return CreateLicenseResponse()
+          ..statusResponse = (StatusResponse()
+            ..type = StatusResponse_Type.SUCCESS
+            ..message = 'License already fulfilled')
+          ..license = License(
+            licenseId: licenseId,
+            licensePlan: plan,
+            providerProductId: providerProductId,
+            providerPriceId: providerPriceId,
+            maxUsers: maxUsers,
+            paymentProvider: PaymentProvider.PAYMENT_PROVIDER_STRIPE,
+          );
+      }
+      rethrow;
     }
-    return response;
   }
 
   Future<void> _updateStripeCustomerId(String firmId, String customerId) async {
@@ -612,5 +635,91 @@ class BillingService extends BillingServiceBase {
     } on StripeCheckoutException catch (e) {
       throw GrpcError.internal(e.message);
     }
+  }
+
+  @override
+  Future<CreateLicenseResponse> fulfillFromStripeCheckoutSession(
+      ServiceCall? call, FulfillFromStripeCheckoutSessionRequest request) async {
+    final log = _logger.withContext(call);
+    final userPermission = _userPermissions(call);
+    _requireFirmId(userPermission);
+    _requireBillingRight(userPermission, Right.create);
+
+    if (request.checkoutSessionId.isEmpty) {
+      throw GrpcError.invalidArgument('checkoutSessionId is required');
+    }
+
+    final secretKey = AppEnvironment.stripeSecretKey;
+    if (secretKey == null || secretKey.isEmpty) {
+      throw GrpcError.failedPrecondition('Stripe not configured');
+    }
+
+    StripeCheckoutSessionInfo sessionInfo;
+    try {
+      sessionInfo = await fetchStripeCheckoutSession(
+        sessionId: request.checkoutSessionId,
+        stripeSecretKey: secretKey,
+      );
+    } on StripeCheckoutException catch (e) {
+      throw GrpcError.notFound('Could not load checkout session: ${e.message}');
+    }
+
+    if (sessionInfo.paymentStatus != 'paid') {
+      throw GrpcError.failedPrecondition(
+        'Session is not paid yet (status: ${sessionInfo.paymentStatus})',
+      );
+    }
+
+    final firmIdFromSession = sessionInfo.metadata['firmId'] ?? '';
+    if (firmIdFromSession != userPermission.firmId) {
+      throw GrpcError.permissionDenied(
+        'This checkout session does not belong to your firm',
+      );
+    }
+
+    if (sessionInfo.priceId.isEmpty) {
+      throw GrpcError.internal('No price in checkout session');
+    }
+
+    final product = await databaseMiddleware<BillingProduct?>(
+      _poolService,
+      (db) async => _lookupBillingProductByStripePriceId(db, sessionInfo.priceId),
+    );
+    if (product == null) {
+      throw GrpcError.invalidArgument('Unknown price: ${sessionInfo.priceId}');
+    }
+
+    final licenseId = 'lic_stripe_${_sanitizeStripeSessionId(sessionInfo.id)}';
+
+    int creditAppliedCents = 0;
+    final creditStr = sessionInfo.metadata['creditAppliedCents'];
+    if (creditStr != null && creditStr.isNotEmpty) {
+      creditAppliedCents = int.tryParse(creditStr) ?? 0;
+    }
+    final referralCode = sessionInfo.metadata['referralCode'] ?? '';
+
+    log.logRpcEntry('fulfillFromStripeCheckoutSession', requestData: {
+      'firmId': userPermission.firmId,
+      'sessionId': sessionInfo.id,
+    });
+
+    final response = await _fulfillLicenseFromStripeInternal(
+      userPermission.firmId,
+      licenseId,
+      product.licensePlan,
+      product.stripeProductId,
+      product.stripePriceId,
+      product.maxUsers,
+      stripeCustomerId: sessionInfo.customer,
+      referralCode: referralCode.isNotEmpty ? referralCode : null,
+      creditAppliedCents: creditAppliedCents,
+    );
+
+    log.logRpcExit('fulfillFromStripeCheckoutSession');
+    return response;
+  }
+
+  static String _sanitizeStripeSessionId(String sessionId) {
+    return sessionId.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
   }
 }

--- a/packages/billing_service/lib/src/stripe_checkout.dart
+++ b/packages/billing_service/lib/src/stripe_checkout.dart
@@ -68,6 +68,70 @@ Map<String, dynamic> _parseStripeResponse(String body) {
   );
 }
 
+/// Fetched Checkout Session fields needed for fulfillment.
+class StripeCheckoutSessionInfo {
+  const StripeCheckoutSessionInfo({
+    required this.id,
+    required this.paymentStatus,
+    required this.metadata,
+    required this.priceId,
+    this.customer,
+  });
+  final String id;
+  final String paymentStatus;
+  final Map<String, String> metadata;
+  final String priceId;
+  final String? customer;
+}
+
+/// Fetches a Checkout Session from Stripe (for sync-after-redirect).
+Future<StripeCheckoutSessionInfo> fetchStripeCheckoutSession({
+  required String sessionId,
+  required String stripeSecretKey,
+}) async {
+  final uri = Uri.parse(
+    'https://api.stripe.com/v1/checkout/sessions/$sessionId'
+    '?expand[]=line_items.data.price',
+  );
+  final resp = await http.get(
+    uri,
+    headers: {
+      'Authorization': 'Bearer $stripeSecretKey',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  );
+  if (resp.statusCode != 200) {
+    throw StripeCheckoutException(
+      'Stripe API error: ${resp.statusCode} ${resp.body}',
+    );
+  }
+  final session = _parseStripeResponse(resp.body);
+  final paymentStatus = session['payment_status'] as String? ?? '';
+  final metadataMap = session['metadata'] as Map<String, dynamic>? ?? {};
+  final metadata = <String, String>{};
+  for (final e in metadataMap.entries) {
+    if (e.value != null) metadata[e.key.toString()] = e.value.toString();
+  }
+  String priceId = '';
+  final lineItems = session['line_items'] as Map<String, dynamic>?;
+  if (lineItems != null) {
+    final data = lineItems['data'] as List<dynamic>?;
+    if (data != null && data.isNotEmpty) {
+      final first = data[0] as Map<String, dynamic>?;
+      final price = first?['price'] as Map<String, dynamic>?;
+      if (price != null) priceId = price['id'] as String? ?? '';
+    }
+  }
+  final customer = session['customer'] as String?;
+  return StripeCheckoutSessionInfo(
+    id: session['id'] as String? ?? '',
+    paymentStatus: paymentStatus,
+    metadata: metadata,
+    priceId: priceId,
+    customer: customer != null && customer.isNotEmpty ? customer : null,
+  );
+}
+
 class StripeCheckoutException implements Exception {
   final String message;
   StripeCheckoutException(this.message);

--- a/packages/protos/protos_weebi/lib/src/generated/billing_service.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/billing_service.pb.dart
@@ -818,6 +818,57 @@ class FulfillLicenseFromStripeRequest extends $pb.GeneratedMessage {
   void clearCreditAppliedCents() => clearField(6);
 }
 
+/// / Request to fulfill a license from a Stripe Checkout Session (e.g. after success redirect).
+class FulfillFromStripeCheckoutSessionRequest extends $pb.GeneratedMessage {
+  factory FulfillFromStripeCheckoutSessionRequest({
+    $core.String? checkoutSessionId,
+  }) {
+    final result = create();
+    if (checkoutSessionId != null) {
+      result.checkoutSessionId = checkoutSessionId;
+    }
+    return result;
+  }
+  FulfillFromStripeCheckoutSessionRequest._() : super();
+  factory FulfillFromStripeCheckoutSessionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FulfillFromStripeCheckoutSessionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FulfillFromStripeCheckoutSessionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'weebi.billing.service'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'checkoutSessionId', protoName: 'checkoutSessionId')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FulfillFromStripeCheckoutSessionRequest clone() => FulfillFromStripeCheckoutSessionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FulfillFromStripeCheckoutSessionRequest copyWith(void Function(FulfillFromStripeCheckoutSessionRequest) updates) => super.copyWith((message) => updates(message as FulfillFromStripeCheckoutSessionRequest)) as FulfillFromStripeCheckoutSessionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FulfillFromStripeCheckoutSessionRequest create() => FulfillFromStripeCheckoutSessionRequest._();
+  FulfillFromStripeCheckoutSessionRequest createEmptyInstance() => create();
+  static $pb.PbList<FulfillFromStripeCheckoutSessionRequest> createRepeated() => $pb.PbList<FulfillFromStripeCheckoutSessionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static FulfillFromStripeCheckoutSessionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FulfillFromStripeCheckoutSessionRequest>(create);
+  static FulfillFromStripeCheckoutSessionRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get checkoutSessionId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set checkoutSessionId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCheckoutSessionId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCheckoutSessionId() => clearField(1);
+}
+
 /// / Billing product (license plan). Stored in billing_products collection.
 /// / Single source of truth for price mapping; replaces STRIPE_PRICE_* and STRIPE_PRODUCT_* env vars.
 class BillingProduct extends $pb.GeneratedMessage {

--- a/packages/protos/protos_weebi/lib/src/generated/billing_service.pbgrpc.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/billing_service.pbgrpc.dart
@@ -63,6 +63,10 @@ class BillingServiceClient extends $grpc.Client {
       '/weebi.billing.service.BillingService/fulfillLicenseFromStripe',
       ($14.FulfillLicenseFromStripeRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $14.CreateLicenseResponse.fromBuffer(value));
+  static final _$fulfillFromStripeCheckoutSession = $grpc.ClientMethod<$14.FulfillFromStripeCheckoutSessionRequest, $14.CreateLicenseResponse>(
+      '/weebi.billing.service.BillingService/fulfillFromStripeCheckoutSession',
+      ($14.FulfillFromStripeCheckoutSessionRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $14.CreateLicenseResponse.fromBuffer(value));
 
   BillingServiceClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
@@ -108,6 +112,10 @@ class BillingServiceClient extends $grpc.Client {
 
   $grpc.ResponseFuture<$14.CreateLicenseResponse> fulfillLicenseFromStripe($14.FulfillLicenseFromStripeRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$fulfillLicenseFromStripe, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$14.CreateLicenseResponse> fulfillFromStripeCheckoutSession($14.FulfillFromStripeCheckoutSessionRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$fulfillFromStripeCheckoutSession, request, options: options);
   }
 }
 
@@ -186,6 +194,13 @@ abstract class BillingServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $14.FulfillLicenseFromStripeRequest.fromBuffer(value),
         ($14.CreateLicenseResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$14.FulfillFromStripeCheckoutSessionRequest, $14.CreateLicenseResponse>(
+        'fulfillFromStripeCheckoutSession',
+        fulfillFromStripeCheckoutSession_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $14.FulfillFromStripeCheckoutSessionRequest.fromBuffer(value),
+        ($14.CreateLicenseResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$14.CreateLicenseResponse> createLicense_Pre($grpc.ServiceCall call, $async.Future<$14.CreateLicenseRequest> request) async {
@@ -228,6 +243,10 @@ abstract class BillingServiceBase extends $grpc.Service {
     return fulfillLicenseFromStripe(call, await request);
   }
 
+  $async.Future<$14.CreateLicenseResponse> fulfillFromStripeCheckoutSession_Pre($grpc.ServiceCall call, $async.Future<$14.FulfillFromStripeCheckoutSessionRequest> request) async {
+    return fulfillFromStripeCheckoutSession(call, await request);
+  }
+
   $async.Future<$14.CreateLicenseResponse> createLicense($grpc.ServiceCall call, $14.CreateLicenseRequest request);
   $async.Future<$14.ReadLicensesResponse> readLicenses($grpc.ServiceCall call, $0.Empty request);
   $async.Future<$14.ReadBillingProductsResponse> readBillingProducts($grpc.ServiceCall call, $0.Empty request);
@@ -238,4 +257,5 @@ abstract class BillingServiceBase extends $grpc.Service {
   $async.Future<$14.RequestReferralPayoutResponse> requestReferralPayout($grpc.ServiceCall call, $0.Empty request);
   $async.Future<$14.CreateCheckoutSessionResponse> createCheckoutSession($grpc.ServiceCall call, $14.CreateCheckoutSessionRequest request);
   $async.Future<$14.CreateLicenseResponse> fulfillLicenseFromStripe($grpc.ServiceCall call, $14.FulfillLicenseFromStripeRequest request);
+  $async.Future<$14.CreateLicenseResponse> fulfillFromStripeCheckoutSession($grpc.ServiceCall call, $14.FulfillFromStripeCheckoutSessionRequest request);
 }

--- a/packages/protos/protos_weebi/lib/src/generated/billing_service.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/billing_service.pbjson.dart
@@ -181,6 +181,19 @@ final $typed_data.Uint8List fulfillLicenseFromStripeRequestDescriptor = $convert
     'JhbENvZGUYBSABKAlSDHJlZmVycmFsQ29kZRIuChJjcmVkaXRBcHBsaWVkQ2VudHMYBiABKAVS'
     'EmNyZWRpdEFwcGxpZWRDZW50cw==');
 
+@$core.Deprecated('Use fulfillFromStripeCheckoutSessionRequestDescriptor instead')
+const FulfillFromStripeCheckoutSessionRequest$json = {
+  '1': 'FulfillFromStripeCheckoutSessionRequest',
+  '2': [
+    {'1': 'checkoutSessionId', '3': 1, '4': 1, '5': 9, '10': 'checkoutSessionId'},
+  ],
+};
+
+/// Descriptor for `FulfillFromStripeCheckoutSessionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List fulfillFromStripeCheckoutSessionRequestDescriptor = $convert.base64Decode(
+    'CidGdWxmaWxsRnJvbVN0cmlwZUNoZWNrb3V0U2Vzc2lvblJlcXVlc3QSLAoRY2hlY2tvdXRTZX'
+    'NzaW9uSWQYASABKAlSEWNoZWNrb3V0U2Vzc2lvbklk');
+
 @$core.Deprecated('Use billingProductDescriptor instead')
 const BillingProduct$json = {
   '1': 'BillingProduct',


### PR DESCRIPTION
- Added new method `fulfillFromStripeCheckoutSession` to handle license fulfillment from a Stripe Checkout Session.
- Introduced `StripeCheckoutSessionInfo` class to encapsulate session details.
- Updated gRPC service definitions and generated protobuf files to include the new request type.
- Enhanced error handling for Stripe session retrieval and validation.
- Updated README for clearer instructions on generating protos and using the new functionality.