### PR TITLE
chore: Update billing_service_test and bump protos_weebi version to 1…

### DIFF
--- a/packages/billing_service/test/billing_service_test.dart
+++ b/packages/billing_service/test/billing_service_test.dart
@@ -1,5 +1,4 @@
 import 'package:fence_service/grpc.dart' show GrpcError;
-import 'package:fence_service/mongo_dart.dart' hide Timestamp;
 import 'package:fence_service/mongo_pool.dart';
 import 'package:fence_service/protos_weebi.dart';
 import 'package:fence_service/mongo_local_testing.dart';

--- a/packages/protos/protos_weebi/CHANGELOG.md
+++ b/packages/protos/protos_weebi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.1.1 - 2026 march
+
+- add fulfillFromStripeCheckoutSession in billingServiceClient
+
 ## 1.1.0 - 2026 march
 
 - add billing_service and related protos

--- a/packages/protos/protos_weebi/pubspec.yaml
+++ b/packages/protos/protos_weebi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: protos_weebi
 description: protos for weebi
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/weebi-com/weebi_server/
 homepage: https://www.weebi.com
 


### PR DESCRIPTION
….1.1

- Removed unused import from billing_service_test.dart.
- Added `fulfillFromStripeCheckoutSession` method to CHANGELOG.md.
- Updated version number to 1.1.1 in pubspec.yaml.