### PR TITLE
chore: Release version 1.0.9 with legal terms versioning

### DIFF
--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# changelog
+## 1.0.9 - march 2026
+
+- terms and conditions versions
+
 ## 1.0.8 - march 2026
 
 - billing_service and payment integration

--- a/apps/server/pubspec.yaml
+++ b/apps/server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: server
 description: weebi gRPC server
-version: 1.0.8
+version: 1.0.9
 publish_to: none
 # repository: https://github.com/my_org/my_repo
 

--- a/packages/billing_service/lib/src/billing_service_base.dart
+++ b/packages/billing_service/lib/src/billing_service_base.dart
@@ -227,7 +227,26 @@ class BillingService extends BillingServiceBase {
       stripeCustomerId: request.stripeCustomerId.isNotEmpty ? request.stripeCustomerId : null,
       referralCode: request.referralCode.isNotEmpty ? request.referralCode : null,
       creditAppliedCents: request.creditAppliedCents,
+      legalTermsVersionDate: request.legalTermsVersionDate.isNotEmpty
+          ? request.legalTermsVersionDate
+          : null,
     );
+  }
+
+  static final RegExp _legalTermsDatePattern = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+
+  void _validateLegalTermsVersionDate(String value) {
+    final v = value.trim();
+    if (v.isEmpty) {
+      throw GrpcError.invalidArgument(
+        'legalTermsVersionDate is required (YYYY-MM-DD)',
+      );
+    }
+    if (!_legalTermsDatePattern.hasMatch(v)) {
+      throw GrpcError.invalidArgument(
+        'legalTermsVersionDate must be YYYY-MM-DD',
+      );
+    }
   }
 
   /// Internal: fulfill a license after Stripe payment. Called by RPC (service account) or tests.
@@ -242,7 +261,9 @@ class BillingService extends BillingServiceBase {
     String? stripeCustomerId,
     String? referralCode,
     int creditAppliedCents = 0,
+    String? legalTermsVersionDate,
   }) async {
+    final termsDate = legalTermsVersionDate?.trim() ?? '';
     final request = CreateLicenseRequest(
       license: License(
         licenseId: licenseId,
@@ -252,6 +273,7 @@ class BillingService extends BillingServiceBase {
         maxUsers: maxUsers,
         validFrom: DateTime.now().toUtc().timestampProto,
         paymentProvider: PaymentProvider.PAYMENT_PROVIDER_STRIPE,
+        legalTermsVersionDate: termsDate,
       ),
       referralCode: referralCode ?? '',
       creditAppliedCents: creditAppliedCents,
@@ -268,6 +290,9 @@ class BillingService extends BillingServiceBase {
         if (stripeCustomerId != null && stripeCustomerId.isNotEmpty) {
           await _updateStripeCustomerId(firmId, stripeCustomerId);
         }
+        if (termsDate.isNotEmpty) {
+          await _backfillLegalTermsOnExistingLicense(firmId, licenseId, termsDate);
+        }
         return CreateLicenseResponse()
           ..statusResponse = (StatusResponse()
             ..type = StatusResponse_Type.SUCCESS
@@ -279,6 +304,7 @@ class BillingService extends BillingServiceBase {
             providerPriceId: providerPriceId,
             maxUsers: maxUsers,
             paymentProvider: PaymentProvider.PAYMENT_PROVIDER_STRIPE,
+            legalTermsVersionDate: termsDate,
           );
       }
       rethrow;
@@ -291,6 +317,54 @@ class BillingService extends BillingServiceBase {
         where.eq('firmId', firmId),
         ModifierBuilder().set('providerCustomerIds.stripe', customerId),
       );
+    });
+  }
+
+  /// When the webhook created the license first, [legalTermsVersionDate] may be empty; set it once from the client sync RPC.
+  Future<void> _backfillLegalTermsOnExistingLicense(
+    String firmId,
+    String licenseId,
+    String termsDate,
+  ) async {
+    if (termsDate.isEmpty) return;
+    await databaseMiddleware<void>(_poolService, (db) async {
+      final coll = db.collection(FenceService.firmCollectionName);
+      final firm = await coll.findOne(where.eq('firmId', firmId));
+      if (firm == null) return;
+      final rawList = firm['licenses'] as List?;
+      if (rawList == null || rawList.isEmpty) return;
+
+      var targetIndex = -1;
+      for (var i = 0; i < rawList.length; i++) {
+        final m = Map<String, dynamic>.from(rawList[i] as Map);
+        if (m['licenseId'] != licenseId) continue;
+        final existing = (m['legalTermsVersionDate'] as String?)?.trim() ?? '';
+        if (existing.isNotEmpty) return;
+        targetIndex = i;
+        break;
+      }
+      if (targetIndex < 0) return;
+
+      final newList = <dynamic>[];
+      for (var i = 0; i < rawList.length; i++) {
+        if (i == targetIndex) {
+          final copy = Map<String, dynamic>.from(rawList[i] as Map);
+          copy['legalTermsVersionDate'] = termsDate;
+          newList.add(copy);
+        } else {
+          newList.add(rawList[i]);
+        }
+      }
+
+      final result = await coll.updateOne(
+        where.eq('firmId', firmId),
+        ModifierBuilder().set('licenses', newList),
+      );
+      if (result.nModified != 1) {
+        _logger.warning(
+          'backfill legalTermsVersionDate: expected nModified=1 got ${result.nModified} firm=$firmId license=$licenseId',
+        );
+      }
     });
   }
 
@@ -585,6 +659,7 @@ class BillingService extends BillingServiceBase {
     if (request.cancelUrl.isEmpty) {
       throw GrpcError.invalidArgument('cancelUrl is required');
     }
+    _validateLegalTermsVersionDate(request.legalTermsVersionDate);
 
     final secretKey = AppEnvironment.stripeSecretKey;
     if (secretKey == null || secretKey.isEmpty) {
@@ -601,6 +676,7 @@ class BillingService extends BillingServiceBase {
     log.logRpcEntry('createCheckoutSession', requestData: {
       'firmId': userPermission.firmId,
       'priceId': request.priceId,
+      'legalTermsVersionDate': request.legalTermsVersionDate.trim(),
     });
 
     final customerId = await databaseMiddleware<String?>(_poolService, (db) async {
@@ -648,6 +724,7 @@ class BillingService extends BillingServiceBase {
     if (request.checkoutSessionId.isEmpty) {
       throw GrpcError.invalidArgument('checkoutSessionId is required');
     }
+    _validateLegalTermsVersionDate(request.legalTermsVersionDate);
 
     final secretKey = AppEnvironment.stripeSecretKey;
     if (secretKey == null || secretKey.isEmpty) {
@@ -698,9 +775,12 @@ class BillingService extends BillingServiceBase {
     }
     final referralCode = sessionInfo.metadata['referralCode'] ?? '';
 
+    final termsForLicense = request.legalTermsVersionDate.trim();
+
     log.logRpcEntry('fulfillFromStripeCheckoutSession', requestData: {
       'firmId': userPermission.firmId,
       'sessionId': sessionInfo.id,
+      'legalTermsVersionDate': termsForLicense,
     });
 
     final response = await _fulfillLicenseFromStripeInternal(
@@ -713,6 +793,7 @@ class BillingService extends BillingServiceBase {
       stripeCustomerId: sessionInfo.customer,
       referralCode: referralCode.isNotEmpty ? referralCode : null,
       creditAppliedCents: creditAppliedCents,
+      legalTermsVersionDate: termsForLicense,
     );
 
     log.logRpcExit('fulfillFromStripeCheckoutSession');

--- a/packages/protos/protos_weebi/CHANGELOG.md
+++ b/packages/protos/protos_weebi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.1.2 - 2026 march
+
+- added termsVersion in license
+
 ## 1.1.1 - 2026 march
 
 - add fulfillFromStripeCheckoutSession in billingServiceClient

--- a/packages/protos/protos_weebi/lib/src/generated/billing_service.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/billing_service.pb.dart
@@ -543,6 +543,7 @@ class CreateCheckoutSessionRequest extends $pb.GeneratedMessage {
     $core.String? cancelUrl,
     $core.String? referralCode,
     $core.int? creditAppliedCents,
+    $core.String? legalTermsVersionDate,
   }) {
     final result = create();
     if (priceId != null) {
@@ -560,6 +561,9 @@ class CreateCheckoutSessionRequest extends $pb.GeneratedMessage {
     if (creditAppliedCents != null) {
       result.creditAppliedCents = creditAppliedCents;
     }
+    if (legalTermsVersionDate != null) {
+      result.legalTermsVersionDate = legalTermsVersionDate;
+    }
     return result;
   }
   CreateCheckoutSessionRequest._() : super();
@@ -572,6 +576,7 @@ class CreateCheckoutSessionRequest extends $pb.GeneratedMessage {
     ..aOS(3, _omitFieldNames ? '' : 'cancelUrl', protoName: 'cancelUrl')
     ..aOS(4, _omitFieldNames ? '' : 'referralCode', protoName: 'referralCode')
     ..a<$core.int>(5, _omitFieldNames ? '' : 'creditAppliedCents', $pb.PbFieldType.O3, protoName: 'creditAppliedCents')
+    ..aOS(6, _omitFieldNames ? '' : 'legalTermsVersionDate', protoName: 'legalTermsVersionDate')
     ..hasRequiredFields = false
   ;
 
@@ -645,6 +650,16 @@ class CreateCheckoutSessionRequest extends $pb.GeneratedMessage {
   $core.bool hasCreditAppliedCents() => $_has(4);
   @$pb.TagNumber(5)
   void clearCreditAppliedCents() => clearField(5);
+
+  /// / CGV / terms version the buyer accepted before checkout (YYYY-MM-DD, one revision per day).
+  @$pb.TagNumber(6)
+  $core.String get legalTermsVersionDate => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set legalTermsVersionDate($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasLegalTermsVersionDate() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearLegalTermsVersionDate() => clearField(6);
 }
 
 class CreateCheckoutSessionResponse extends $pb.GeneratedMessage {
@@ -706,6 +721,7 @@ class FulfillLicenseFromStripeRequest extends $pb.GeneratedMessage {
     $core.String? stripeCustomerId,
     $core.String? referralCode,
     $core.int? creditAppliedCents,
+    $core.String? legalTermsVersionDate,
   }) {
     final result = create();
     if (firmId != null) {
@@ -726,6 +742,9 @@ class FulfillLicenseFromStripeRequest extends $pb.GeneratedMessage {
     if (creditAppliedCents != null) {
       result.creditAppliedCents = creditAppliedCents;
     }
+    if (legalTermsVersionDate != null) {
+      result.legalTermsVersionDate = legalTermsVersionDate;
+    }
     return result;
   }
   FulfillLicenseFromStripeRequest._() : super();
@@ -739,6 +758,7 @@ class FulfillLicenseFromStripeRequest extends $pb.GeneratedMessage {
     ..aOS(4, _omitFieldNames ? '' : 'stripeCustomerId', protoName: 'stripeCustomerId')
     ..aOS(5, _omitFieldNames ? '' : 'referralCode', protoName: 'referralCode')
     ..a<$core.int>(6, _omitFieldNames ? '' : 'creditAppliedCents', $pb.PbFieldType.O3, protoName: 'creditAppliedCents')
+    ..aOS(7, _omitFieldNames ? '' : 'legalTermsVersionDate', protoName: 'legalTermsVersionDate')
     ..hasRequiredFields = false
   ;
 
@@ -816,16 +836,30 @@ class FulfillLicenseFromStripeRequest extends $pb.GeneratedMessage {
   $core.bool hasCreditAppliedCents() => $_has(5);
   @$pb.TagNumber(6)
   void clearCreditAppliedCents() => clearField(6);
+
+  /// / CGV / terms version from checkout session metadata (YYYY-MM-DD).
+  @$pb.TagNumber(7)
+  $core.String get legalTermsVersionDate => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set legalTermsVersionDate($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasLegalTermsVersionDate() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearLegalTermsVersionDate() => clearField(7);
 }
 
 /// / Request to fulfill a license from a Stripe Checkout Session (e.g. after success redirect).
 class FulfillFromStripeCheckoutSessionRequest extends $pb.GeneratedMessage {
   factory FulfillFromStripeCheckoutSessionRequest({
     $core.String? checkoutSessionId,
+    $core.String? legalTermsVersionDate,
   }) {
     final result = create();
     if (checkoutSessionId != null) {
       result.checkoutSessionId = checkoutSessionId;
+    }
+    if (legalTermsVersionDate != null) {
+      result.legalTermsVersionDate = legalTermsVersionDate;
     }
     return result;
   }
@@ -835,6 +869,7 @@ class FulfillFromStripeCheckoutSessionRequest extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FulfillFromStripeCheckoutSessionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'weebi.billing.service'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'checkoutSessionId', protoName: 'checkoutSessionId')
+    ..aOS(2, _omitFieldNames ? '' : 'legalTermsVersionDate', protoName: 'legalTermsVersionDate')
     ..hasRequiredFields = false
   ;
 
@@ -867,6 +902,16 @@ class FulfillFromStripeCheckoutSessionRequest extends $pb.GeneratedMessage {
   $core.bool hasCheckoutSessionId() => $_has(0);
   @$pb.TagNumber(1)
   void clearCheckoutSessionId() => clearField(1);
+
+  /// / Same value as sent to createCheckoutSession (YYYY-MM-DD). Persisted on the license; not read from Stripe.
+  @$pb.TagNumber(2)
+  $core.String get legalTermsVersionDate => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set legalTermsVersionDate($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasLegalTermsVersionDate() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLegalTermsVersionDate() => clearField(2);
 }
 
 /// / Billing product (license plan). Stored in billing_products collection.

--- a/packages/protos/protos_weebi/lib/src/generated/billing_service.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/billing_service.pbjson.dart
@@ -137,6 +137,7 @@ const CreateCheckoutSessionRequest$json = {
     {'1': 'cancelUrl', '3': 3, '4': 1, '5': 9, '10': 'cancelUrl'},
     {'1': 'referralCode', '3': 4, '4': 1, '5': 9, '10': 'referralCode'},
     {'1': 'creditAppliedCents', '3': 5, '4': 1, '5': 5, '10': 'creditAppliedCents'},
+    {'1': 'legalTermsVersionDate', '3': 6, '4': 1, '5': 9, '10': 'legalTermsVersionDate'},
   ],
 };
 
@@ -145,7 +146,8 @@ final $typed_data.Uint8List createCheckoutSessionRequestDescriptor = $convert.ba
     'ChxDcmVhdGVDaGVja291dFNlc3Npb25SZXF1ZXN0EhgKB3ByaWNlSWQYASABKAlSB3ByaWNlSW'
     'QSHgoKc3VjY2Vzc1VybBgCIAEoCVIKc3VjY2Vzc1VybBIcCgljYW5jZWxVcmwYAyABKAlSCWNh'
     'bmNlbFVybBIiCgxyZWZlcnJhbENvZGUYBCABKAlSDHJlZmVycmFsQ29kZRIuChJjcmVkaXRBcH'
-    'BsaWVkQ2VudHMYBSABKAVSEmNyZWRpdEFwcGxpZWRDZW50cw==');
+    'BsaWVkQ2VudHMYBSABKAVSEmNyZWRpdEFwcGxpZWRDZW50cxI0ChVsZWdhbFRlcm1zVmVyc2lv'
+    'bkRhdGUYBiABKAlSFWxlZ2FsVGVybXNWZXJzaW9uRGF0ZQ==');
 
 @$core.Deprecated('Use createCheckoutSessionResponseDescriptor instead')
 const CreateCheckoutSessionResponse$json = {
@@ -170,6 +172,7 @@ const FulfillLicenseFromStripeRequest$json = {
     {'1': 'stripeCustomerId', '3': 4, '4': 1, '5': 9, '10': 'stripeCustomerId'},
     {'1': 'referralCode', '3': 5, '4': 1, '5': 9, '10': 'referralCode'},
     {'1': 'creditAppliedCents', '3': 6, '4': 1, '5': 5, '10': 'creditAppliedCents'},
+    {'1': 'legalTermsVersionDate', '3': 7, '4': 1, '5': 9, '10': 'legalTermsVersionDate'},
   ],
 };
 
@@ -179,20 +182,23 @@ final $typed_data.Uint8List fulfillLicenseFromStripeRequestDescriptor = $convert
     'lkEhwKCWxpY2Vuc2VJZBgCIAEoCVIJbGljZW5zZUlkEhgKB3ByaWNlSWQYAyABKAlSB3ByaWNl'
     'SWQSKgoQc3RyaXBlQ3VzdG9tZXJJZBgEIAEoCVIQc3RyaXBlQ3VzdG9tZXJJZBIiCgxyZWZlcn'
     'JhbENvZGUYBSABKAlSDHJlZmVycmFsQ29kZRIuChJjcmVkaXRBcHBsaWVkQ2VudHMYBiABKAVS'
-    'EmNyZWRpdEFwcGxpZWRDZW50cw==');
+    'EmNyZWRpdEFwcGxpZWRDZW50cxI0ChVsZWdhbFRlcm1zVmVyc2lvbkRhdGUYByABKAlSFWxlZ2'
+    'FsVGVybXNWZXJzaW9uRGF0ZQ==');
 
 @$core.Deprecated('Use fulfillFromStripeCheckoutSessionRequestDescriptor instead')
 const FulfillFromStripeCheckoutSessionRequest$json = {
   '1': 'FulfillFromStripeCheckoutSessionRequest',
   '2': [
     {'1': 'checkoutSessionId', '3': 1, '4': 1, '5': 9, '10': 'checkoutSessionId'},
+    {'1': 'legalTermsVersionDate', '3': 2, '4': 1, '5': 9, '10': 'legalTermsVersionDate'},
   ],
 };
 
 /// Descriptor for `FulfillFromStripeCheckoutSessionRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List fulfillFromStripeCheckoutSessionRequestDescriptor = $convert.base64Decode(
     'CidGdWxmaWxsRnJvbVN0cmlwZUNoZWNrb3V0U2Vzc2lvblJlcXVlc3QSLAoRY2hlY2tvdXRTZX'
-    'NzaW9uSWQYASABKAlSEWNoZWNrb3V0U2Vzc2lvbklk');
+    'NzaW9uSWQYASABKAlSEWNoZWNrb3V0U2Vzc2lvbklkEjQKFWxlZ2FsVGVybXNWZXJzaW9uRGF0'
+    'ZRgCIAEoCVIVbGVnYWxUZXJtc1ZlcnNpb25EYXRl');
 
 @$core.Deprecated('Use billingProductDescriptor instead')
 const BillingProduct$json = {

--- a/packages/protos/protos_weebi/lib/src/generated/license.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/license.pb.dart
@@ -33,6 +33,7 @@ class License extends $pb.GeneratedMessage {
     PaymentProvider? paymentProvider,
     $core.String? referredByFirmId,
     $core.int? creditAppliedCents,
+    $core.String? legalTermsVersionDate,
   }) {
     final result = create();
     if (licenseId != null) {
@@ -68,6 +69,9 @@ class License extends $pb.GeneratedMessage {
     if (creditAppliedCents != null) {
       result.creditAppliedCents = creditAppliedCents;
     }
+    if (legalTermsVersionDate != null) {
+      result.legalTermsVersionDate = legalTermsVersionDate;
+    }
     return result;
   }
   License._() : super();
@@ -86,6 +90,7 @@ class License extends $pb.GeneratedMessage {
     ..e<PaymentProvider>(9, _omitFieldNames ? '' : 'paymentProvider', $pb.PbFieldType.OE, protoName: 'paymentProvider', defaultOrMaker: PaymentProvider.PAYMENT_PROVIDER_UNKNOWN, valueOf: PaymentProvider.valueOf, enumValues: PaymentProvider.values)
     ..aOS(10, _omitFieldNames ? '' : 'referredByFirmId', protoName: 'referredByFirmId')
     ..a<$core.int>(11, _omitFieldNames ? '' : 'creditAppliedCents', $pb.PbFieldType.O3, protoName: 'creditAppliedCents')
+    ..aOS(12, _omitFieldNames ? '' : 'legalTermsVersionDate', protoName: 'legalTermsVersionDate')
     ..hasRequiredFields = false
   ;
 
@@ -210,6 +215,16 @@ class License extends $pb.GeneratedMessage {
   $core.bool hasCreditAppliedCents() => $_has(10);
   @$pb.TagNumber(11)
   void clearCreditAppliedCents() => clearField(11);
+
+  /// / CGV / terms version accepted for this purchase (YYYY-MM-DD).
+  @$pb.TagNumber(12)
+  $core.String get legalTermsVersionDate => $_getSZ(11);
+  @$pb.TagNumber(12)
+  set legalTermsVersionDate($core.String v) { $_setString(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasLegalTermsVersionDate() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearLegalTermsVersionDate() => clearField(12);
 }
 
 /// / Per-seat validity. Each user (seat) has its own start/end dates.

--- a/packages/protos/protos_weebi/lib/src/generated/license.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/license.pbjson.dart
@@ -59,6 +59,7 @@ const License$json = {
     {'1': 'paymentProvider', '3': 9, '4': 1, '5': 14, '6': '.weebi.license.PaymentProvider', '10': 'paymentProvider'},
     {'1': 'referredByFirmId', '3': 10, '4': 1, '5': 9, '10': 'referredByFirmId'},
     {'1': 'creditAppliedCents', '3': 11, '4': 1, '5': 5, '10': 'creditAppliedCents'},
+    {'1': 'legalTermsVersionDate', '3': 12, '4': 1, '5': 9, '10': 'legalTermsVersionDate'},
   ],
 };
 
@@ -73,7 +74,8 @@ final $typed_data.Uint8List licenseDescriptor = $convert.base64Decode(
     'aWwSMAoFc2VhdHMYCCADKAsyGi53ZWViaS5saWNlbnNlLkxpY2Vuc2VTZWF0UgVzZWF0cxJICg'
     '9wYXltZW50UHJvdmlkZXIYCSABKA4yHi53ZWViaS5saWNlbnNlLlBheW1lbnRQcm92aWRlclIP'
     'cGF5bWVudFByb3ZpZGVyEioKEHJlZmVycmVkQnlGaXJtSWQYCiABKAlSEHJlZmVycmVkQnlGaX'
-    'JtSWQSLgoSY3JlZGl0QXBwbGllZENlbnRzGAsgASgFUhJjcmVkaXRBcHBsaWVkQ2VudHM=');
+    'JtSWQSLgoSY3JlZGl0QXBwbGllZENlbnRzGAsgASgFUhJjcmVkaXRBcHBsaWVkQ2VudHMSNAoV'
+    'bGVnYWxUZXJtc1ZlcnNpb25EYXRlGAwgASgJUhVsZWdhbFRlcm1zVmVyc2lvbkRhdGU=');
 
 @$core.Deprecated('Use licenseSeatDescriptor instead')
 const LicenseSeat$json = {

--- a/packages/protos/protos_weebi/pubspec.yaml
+++ b/packages/protos/protos_weebi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: protos_weebi
 description: protos for weebi
-version: 1.1.1
+version: 1.2.1
 repository: https://github.com/weebi-com/weebi_server/
 homepage: https://www.weebi.com
 


### PR DESCRIPTION
- Updated CHANGELOG.md to include new version and terms and conditions.
- Bumped version number to 1.0.9 in pubspec.yaml.
- Enhanced BillingService to support legal terms version date validation and backfilling for existing licenses.
- Updated protobuf definitions to include legalTermsVersionDate in relevant requests and responses.