### PR TITLE
feat: Bump protos version to 1.2.7 and update currency handling

### DIFF
--- a/.protos-version
+++ b/.protos-version
@@ -2,7 +2,7 @@
 # This file specifies which version of the protos repository to use
 
 # Version tag (e.g., v1.0.0) or branch name (e.g., main)
-#PROTOS_VERSION=1.2.5
+#PROTOS_VERSION=1.2.7
 
 # Branch or tag to checkout (use main for latest)
 PROTOS_COMMIT=main

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
-## 1.1.2 - march 2026
+
+
+## 1.1.3 - march 2026
 
 - handle currency
 - handle dual currency

--- a/apps/server/pubspec.yaml
+++ b/apps/server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: server
 description: weebi gRPC server
-version: 1.1.2
+version: 1.1.3
 publish_to: none
 # repository: https://github.com/my_org/my_repo
 

--- a/apps/server/pubspec_overrides.yaml
+++ b/apps/server/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
+# melos_managed_dependency_overrides: billing_service
 # melos_managed_dependency_overrides: protos_weebi
 # melos_managed_dependency_overrides: article_service,boutique_service,contact_service,ticket_service,fence_service
 dependency_overrides:
@@ -11,3 +12,5 @@ dependency_overrides:
     path: ../../packages/fence_service
   protos_weebi:
     path: ../../packages/protos/protos_weebi
+  billing_service:
+    path: ..\\..\\packages\\billing_service

--- a/doc/currency_and_migration.md
+++ b/doc/currency_and_migration.md
@@ -16,7 +16,7 @@ Effective billing currency for a boutique:
 
 ## Dual currency and tickets
 
-- `Firm` / `Chain` may define `dual_currency_enabled` and `secondary_display_currency` (e.g. USD) for product policy; enforcement of licenses is not wired in code yet.
+- `Firm` / `Chain` may define `dualCurrencyEnabled` and `secondaryDisplayCurrency` (e.g. USD) for product policy; enforcement of licenses is not wired in code yet.
 - Each ticket may store an optional FX **snapshot** set at sale time by the client:
   - `snapshot_secondary_currency`
   - `snapshot_local_per_secondary` — units of **local** currency for **one** unit of the secondary currency (e.g. `2800` means 1 USD = 2800 CDF).

--- a/doc/entitlements.md
+++ b/doc/entitlements.md
@@ -25,5 +25,6 @@ Server reference: [`license_seat_entitlement.dart`](../../weebi_server/packages/
 
 - **Webapp:** Prefer [`SeatCapability`](../lib/billing/seat_capability.dart) for seat-gated UI instead of ad hoc `LicenseSeatClient` calls.
 - **Server:** Prefer [`entitlement_helpers.dart`](../../weebi_server/packages/fence_service/lib/src/entitlement_helpers.dart) names (`firmCreatorOperationalJoker`, `userHasActiveLicensedSeat`) alongside `LicenseSeatEntitlement` for clarity.
+- **Dart packages (`users_weebi`):** [`firm_license_seat_utils`](../../weebi/packages/users/lib/src/firm_license_seat_utils.dart) exposes `firmCreatorOperationalJoker` (same meaning as server) and `userHasActiveLicensedSeat` for portal/access UI copy; seat checks stay strict—only messaging distinguishes the joker when `isFirmCreator` and there is no seat.
 
 Future firm-level entitlements (e.g. metered analytics) should be documented here as a third category when introduced.

--- a/packages/billing_service/melos_billing_service.iml
+++ b/packages/billing_service/melos_billing_service.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/packages/billing_service/pubspec_overrides.yaml
+++ b/packages/billing_service/pubspec_overrides.yaml
@@ -4,4 +4,4 @@ dependency_overrides:
   fence_service:
     path: ../fence_service
   protos_weebi:
-    path: ../protos/protos_weebi
+    path: ..\\protos\\protos_weebi

--- a/packages/fence_service/lib/src/currency_resolution.dart
+++ b/packages/fence_service/lib/src/currency_resolution.dart
@@ -12,8 +12,8 @@ class CurrencyResolution {
 
   /// Firm document default, else [platformDefault].
   static String firmDefaultOrPlatform(Firm firm, String platformDefault) {
-    if (firm.hasDefaultCurrency() && firm.defaultCurrency.trim().isNotEmpty) {
-      return normalizeOr(firm.defaultCurrency, platformDefault);
+    if (firm.hasCurrency() && firm.currency.trim().isNotEmpty) {
+      return normalizeOr(firm.currency, platformDefault);
     }
     return platformDefault;
   }

--- a/packages/fence_service/lib/src/fence_service_base.dart
+++ b/packages/fence_service/lib/src/fence_service_base.dart
@@ -1351,10 +1351,10 @@ class FenceService extends FenceServiceBase {
 
     final firmId = DateTime.now().objectIdString;
     final platformCurrency = AppEnvironment.platformDefaultCurrency;
-    final defaultCurrencyCode = request.hasDefaultCurrency() &&
-            request.defaultCurrency.trim().isNotEmpty
+    final defaultCurrencyCode = request.hasCurrency() &&
+            request.currency.trim().isNotEmpty
         ? CurrencyResolution.normalizeOr(
-            request.defaultCurrency, platformCurrency)
+            request.currency, platformCurrency)
         : platformCurrency;
 
     final firm = Firm(
@@ -1362,7 +1362,7 @@ class FenceService extends FenceServiceBase {
       name: request.name,
       status: true,
       creationDateUTC: nowProtoUTC,
-    )..defaultCurrency = defaultCurrencyCode;
+    )..currency = defaultCurrencyCode;
 
     return databaseMiddleware<CreateFirmResponse>(_poolService, (db) async {
       final firmCollection = db.collection(firmCollectionName);

--- a/packages/fence_service/test/currency_resolution_test.dart
+++ b/packages/fence_service/test/currency_resolution_test.dart
@@ -23,7 +23,7 @@ void main() {
     test('uses boutique currency when set', () {
       final boutique = BoutiquePb.create()..currency = 'xof';
       final chain = Chain.create()..currency = 'USD';
-      final firm = Firm.create()..defaultCurrency = 'EUR';
+      final firm = Firm.create()..currency = 'EUR';
 
       final res = CurrencyResolution.effectiveForBoutique(
         boutique: boutique,
@@ -38,7 +38,7 @@ void main() {
     test('falls back to chain currency', () {
       final boutique = BoutiquePb.create(); // no currency
       final chain = Chain.create()..currency = 'USD';
-      final firm = Firm.create()..defaultCurrency = 'EUR';
+      final firm = Firm.create()..currency = 'EUR';
 
       final res = CurrencyResolution.effectiveForBoutique(
         boutique: boutique,
@@ -53,7 +53,7 @@ void main() {
     test('falls back to firm default currency', () {
       final boutique = BoutiquePb.create();
       final chain = Chain.create();
-      final firm = Firm.create()..defaultCurrency = 'cdf';
+      final firm = Firm.create()..currency = 'cdf';
 
       final res = CurrencyResolution.effectiveForBoutique(
         boutique: boutique,

--- a/packages/protos/protos_weebi/CHANGELOG.md
+++ b/packages/protos/protos_weebi/CHANGELOG.md
@@ -1,8 +1,9 @@
 # changelog
 
-## 1.2.3 - 2026 march
+## 1.2.7 - 2026 march
 
 - currency
+- 2nd currency display
 
 ## 1.1.2 - 2026 march
 

--- a/packages/protos/protos_weebi/lib/src/generated/boutique.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/boutique.pb.dart
@@ -265,6 +265,8 @@ class BoutiquePb extends $pb.GeneratedMessage {
     $core.String? restoredBy,
     $core.String? mail,
     $core.String? currency,
+    $core.bool? dualCurrencyEnabled,
+    $core.String? secondaryDisplayCurrency,
     $core.Map<$core.String, $core.String>? additionalAttributes,
   }) {
     final result = create();
@@ -318,6 +320,12 @@ class BoutiquePb extends $pb.GeneratedMessage {
     if (currency != null) {
       result.currency = currency;
     }
+    if (dualCurrencyEnabled != null) {
+      result.dualCurrencyEnabled = dualCurrencyEnabled;
+    }
+    if (secondaryDisplayCurrency != null) {
+      result.secondaryDisplayCurrency = secondaryDisplayCurrency;
+    }
     if (additionalAttributes != null) {
       result.additionalAttributes.addAll(additionalAttributes);
     }
@@ -344,6 +352,8 @@ class BoutiquePb extends $pb.GeneratedMessage {
     ..aOS(14, _omitFieldNames ? '' : 'restoredBy', protoName: 'restoredBy')
     ..aOS(15, _omitFieldNames ? '' : 'mail')
     ..aOS(16, _omitFieldNames ? '' : 'currency')
+    ..aOB(17, _omitFieldNames ? '' : 'dualCurrencyEnabled', protoName: 'dualCurrencyEnabled')
+    ..aOS(18, _omitFieldNames ? '' : 'secondaryDisplayCurrency', protoName: 'secondaryDisplayCurrency')
     ..m<$core.String, $core.String>(99, _omitFieldNames ? '' : 'additional_attributes', entryClassName: 'BoutiquePb.AdditionalAttributesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('weebi.boutique'))
     ..hasRequiredFields = false
   ;
@@ -526,8 +536,28 @@ class BoutiquePb extends $pb.GeneratedMessage {
   @$pb.TagNumber(16)
   void clearCurrency() => clearField(16);
 
+  /// / When true, PoS/web clients may show amounts in secondaryDisplayCurrency (display-only; same semantics as chain/firm).
+  @$pb.TagNumber(17)
+  $core.bool get dualCurrencyEnabled => $_getBF(16);
+  @$pb.TagNumber(17)
+  set dualCurrencyEnabled($core.bool v) { $_setBool(16, v); }
+  @$pb.TagNumber(17)
+  $core.bool hasDualCurrencyEnabled() => $_has(16);
+  @$pb.TagNumber(17)
+  void clearDualCurrencyEnabled() => clearField(17);
+
+  /// / ISO 4217 secondary display code (e.g. USD). Meaningful when dualCurrencyEnabled is true.
+  @$pb.TagNumber(18)
+  $core.String get secondaryDisplayCurrency => $_getSZ(17);
+  @$pb.TagNumber(18)
+  set secondaryDisplayCurrency($core.String v) { $_setString(17, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasSecondaryDisplayCurrency() => $_has(17);
+  @$pb.TagNumber(18)
+  void clearSecondaryDisplayCurrency() => clearField(18);
+
   @$pb.TagNumber(99)
-  $core.Map<$core.String, $core.String> get additionalAttributes => $_getMap(16);
+  $core.Map<$core.String, $core.String> get additionalAttributes => $_getMap(18);
 }
 
 

--- a/packages/protos/protos_weebi/lib/src/generated/boutique.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/boutique.pbjson.dart
@@ -99,14 +99,18 @@ const BoutiquePb$json = {
     {'1': 'restoredBy', '3': 14, '4': 1, '5': 9, '10': 'restoredBy'},
     {'1': 'mail', '3': 15, '4': 1, '5': 9, '10': 'mail'},
     {'1': 'currency', '3': 16, '4': 1, '5': 9, '9': 0, '10': 'currency', '17': true},
+    {'1': 'dualCurrencyEnabled', '3': 17, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
+    {'1': 'secondaryDisplayCurrency', '3': 18, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
     {'1': 'additional_attributes', '3': 99, '4': 3, '5': 11, '6': '.weebi.boutique.BoutiquePb.AdditionalAttributesEntry', '10': 'additional_attributes'},
   ],
   '3': [BoutiquePb_AdditionalAttributesEntry$json],
   '8': [
     {'1': '_currency'},
+    {'1': '_dualCurrencyEnabled'},
+    {'1': '_secondaryDisplayCurrency'},
   ],
   '9': [
-    {'1': 17, '2': 99},
+    {'1': 19, '2': 99},
   ],
 };
 
@@ -131,9 +135,12 @@ final $typed_data.Uint8List boutiquePbDescriptor = $convert.base64Decode(
     'IAEoAVIFcHJvbW8SHgoKcHJvbW9TdGFydBgKIAEoCVIKcHJvbW9TdGFydBIaCghwcm9tb0VuZB'
     'gLIAEoCVIIcHJvbW9FbmQSHAoJaXNEZWxldGVkGAwgASgIUglpc0RlbGV0ZWQSHAoJZGVsZXRl'
     'ZEJ5GA0gASgJUglkZWxldGVkQnkSHgoKcmVzdG9yZWRCeRgOIAEoCVIKcmVzdG9yZWRCeRISCg'
-    'RtYWlsGA8gASgJUgRtYWlsEh8KCGN1cnJlbmN5GBAgASgJSABSCGN1cnJlbmN5iAEBEmoKFWFk'
-    'ZGl0aW9uYWxfYXR0cmlidXRlcxhjIAMoCzI0LndlZWJpLmJvdXRpcXVlLkJvdXRpcXVlUGIuQW'
-    'RkaXRpb25hbEF0dHJpYnV0ZXNFbnRyeVIVYWRkaXRpb25hbF9hdHRyaWJ1dGVzGkcKGUFkZGl0'
-    'aW9uYWxBdHRyaWJ1dGVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBX'
-    'ZhbHVlOgI4AUILCglfY3VycmVuY3lKBAgREGM=');
+    'RtYWlsGA8gASgJUgRtYWlsEh8KCGN1cnJlbmN5GBAgASgJSABSCGN1cnJlbmN5iAEBEjUKE2R1'
+    'YWxDdXJyZW5jeUVuYWJsZWQYESABKAhIAVITZHVhbEN1cnJlbmN5RW5hYmxlZIgBARI/ChhzZW'
+    'NvbmRhcnlEaXNwbGF5Q3VycmVuY3kYEiABKAlIAlIYc2Vjb25kYXJ5RGlzcGxheUN1cnJlbmN5'
+    'iAEBEmoKFWFkZGl0aW9uYWxfYXR0cmlidXRlcxhjIAMoCzI0LndlZWJpLmJvdXRpcXVlLkJvdX'
+    'RpcXVlUGIuQWRkaXRpb25hbEF0dHJpYnV0ZXNFbnRyeVIVYWRkaXRpb25hbF9hdHRyaWJ1dGVz'
+    'GkcKGUFkZGl0aW9uYWxBdHRyaWJ1dGVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdW'
+    'UYAiABKAlSBXZhbHVlOgI4AUILCglfY3VycmVuY3lCFgoUX2R1YWxDdXJyZW5jeUVuYWJsZWRC'
+    'GwoZX3NlY29uZGFyeURpc3BsYXlDdXJyZW5jeUoECBMQYw==');
 

--- a/packages/protos/protos_weebi/lib/src/generated/btq_chain.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/btq_chain.pb.dart
@@ -90,8 +90,8 @@ class Chain extends $pb.GeneratedMessage {
     ..aOS(9, _omitFieldNames ? '' : 'deletedBy', protoName: 'deletedBy')
     ..aOS(10, _omitFieldNames ? '' : 'restoredBy', protoName: 'restoredBy')
     ..aOS(11, _omitFieldNames ? '' : 'currency')
-    ..aOB(12, _omitFieldNames ? '' : 'dualCurrencyEnabled')
-    ..aOS(13, _omitFieldNames ? '' : 'secondaryDisplayCurrency')
+    ..aOB(12, _omitFieldNames ? '' : 'dualCurrencyEnabled', protoName: 'dualCurrencyEnabled')
+    ..aOS(13, _omitFieldNames ? '' : 'secondaryDisplayCurrency', protoName: 'secondaryDisplayCurrency')
     ..hasRequiredFields = false
   ;
 

--- a/packages/protos/protos_weebi/lib/src/generated/btq_chain.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/btq_chain.pbjson.dart
@@ -28,13 +28,13 @@ const Chain$json = {
     {'1': 'deletedBy', '3': 9, '4': 1, '5': 9, '10': 'deletedBy'},
     {'1': 'restoredBy', '3': 10, '4': 1, '5': 9, '10': 'restoredBy'},
     {'1': 'currency', '3': 11, '4': 1, '5': 9, '9': 0, '10': 'currency', '17': true},
-    {'1': 'dual_currency_enabled', '3': 12, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
-    {'1': 'secondary_display_currency', '3': 13, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
+    {'1': 'dualCurrencyEnabled', '3': 12, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
+    {'1': 'secondaryDisplayCurrency', '3': 13, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
   ],
   '8': [
     {'1': '_currency'},
-    {'1': '_dual_currency_enabled'},
-    {'1': '_secondary_display_currency'},
+    {'1': '_dualCurrencyEnabled'},
+    {'1': '_secondaryDisplayCurrency'},
   ],
 };
 
@@ -48,10 +48,10 @@ final $typed_data.Uint8List chainDescriptor = $convert.base64Decode(
     'F0ZVRpbWVzdGFtcFVUQxIwChNsYXN0VXBkYXRlZEJ5dXNlcklkGAcgASgJUhNsYXN0VXBkYXRl'
     'ZEJ5dXNlcklkEhwKCWlzRGVsZXRlZBgIIAEoCFIJaXNEZWxldGVkEhwKCWRlbGV0ZWRCeRgJIA'
     'EoCVIJZGVsZXRlZEJ5Eh4KCnJlc3RvcmVkQnkYCiABKAlSCnJlc3RvcmVkQnkSHwoIY3VycmVu'
-    'Y3kYCyABKAlIAFIIY3VycmVuY3mIAQESNwoVZHVhbF9jdXJyZW5jeV9lbmFibGVkGAwgASgISA'
-    'FSE2R1YWxDdXJyZW5jeUVuYWJsZWSIAQESQQoac2Vjb25kYXJ5X2Rpc3BsYXlfY3VycmVuY3kY'
-    'DSABKAlIAlIYc2Vjb25kYXJ5RGlzcGxheUN1cnJlbmN5iAEBQgsKCV9jdXJyZW5jeUIYChZfZH'
-    'VhbF9jdXJyZW5jeV9lbmFibGVkQh0KG19zZWNvbmRhcnlfZGlzcGxheV9jdXJyZW5jeQ==');
+    'Y3kYCyABKAlIAFIIY3VycmVuY3mIAQESNQoTZHVhbEN1cnJlbmN5RW5hYmxlZBgMIAEoCEgBUh'
+    'NkdWFsQ3VycmVuY3lFbmFibGVkiAEBEj8KGHNlY29uZGFyeURpc3BsYXlDdXJyZW5jeRgNIAEo'
+    'CUgCUhhzZWNvbmRhcnlEaXNwbGF5Q3VycmVuY3mIAQFCCwoJX2N1cnJlbmN5QhYKFF9kdWFsQ3'
+    'VycmVuY3lFbmFibGVkQhsKGV9zZWNvbmRhcnlEaXNwbGF5Q3VycmVuY3k=');
 
 @$core.Deprecated('Use chainsDescriptor instead')
 const Chains$json = {

--- a/packages/protos/protos_weebi/lib/src/generated/fence_service.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/fence_service.pb.dart
@@ -57,8 +57,8 @@ class ChainRequest extends $pb.GeneratedMessage {
     ..aOS(1, _omitFieldNames ? '' : 'chainId', protoName: 'chainId')
     ..aOS(2, _omitFieldNames ? '' : 'name')
     ..aOS(3, _omitFieldNames ? '' : 'currency')
-    ..aOB(4, _omitFieldNames ? '' : 'dualCurrencyEnabled')
-    ..aOS(5, _omitFieldNames ? '' : 'secondaryDisplayCurrency')
+    ..aOB(4, _omitFieldNames ? '' : 'dualCurrencyEnabled', protoName: 'dualCurrencyEnabled')
+    ..aOS(5, _omitFieldNames ? '' : 'secondaryDisplayCurrency', protoName: 'secondaryDisplayCurrency')
     ..hasRequiredFields = false
   ;
 

--- a/packages/protos/protos_weebi/lib/src/generated/fence_service.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/fence_service.pbjson.dart
@@ -20,24 +20,24 @@ const ChainRequest$json = {
     {'1': 'chainId', '3': 1, '4': 1, '5': 9, '10': 'chainId'},
     {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
     {'1': 'currency', '3': 3, '4': 1, '5': 9, '9': 0, '10': 'currency', '17': true},
-    {'1': 'dual_currency_enabled', '3': 4, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
-    {'1': 'secondary_display_currency', '3': 5, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
+    {'1': 'dualCurrencyEnabled', '3': 4, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
+    {'1': 'secondaryDisplayCurrency', '3': 5, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
   ],
   '8': [
     {'1': '_currency'},
-    {'1': '_dual_currency_enabled'},
-    {'1': '_secondary_display_currency'},
+    {'1': '_dualCurrencyEnabled'},
+    {'1': '_secondaryDisplayCurrency'},
   ],
 };
 
 /// Descriptor for `ChainRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List chainRequestDescriptor = $convert.base64Decode(
     'CgxDaGFpblJlcXVlc3QSGAoHY2hhaW5JZBgBIAEoCVIHY2hhaW5JZBISCgRuYW1lGAIgASgJUg'
-    'RuYW1lEh8KCGN1cnJlbmN5GAMgASgJSABSCGN1cnJlbmN5iAEBEjcKFWR1YWxfY3VycmVuY3lf'
-    'ZW5hYmxlZBgEIAEoCEgBUhNkdWFsQ3VycmVuY3lFbmFibGVkiAEBEkEKGnNlY29uZGFyeV9kaX'
-    'NwbGF5X2N1cnJlbmN5GAUgASgJSAJSGHNlY29uZGFyeURpc3BsYXlDdXJyZW5jeYgBAUILCglf'
-    'Y3VycmVuY3lCGAoWX2R1YWxfY3VycmVuY3lfZW5hYmxlZEIdChtfc2Vjb25kYXJ5X2Rpc3BsYX'
-    'lfY3VycmVuY3k=');
+    'RuYW1lEh8KCGN1cnJlbmN5GAMgASgJSABSCGN1cnJlbmN5iAEBEjUKE2R1YWxDdXJyZW5jeUVu'
+    'YWJsZWQYBCABKAhIAVITZHVhbEN1cnJlbmN5RW5hYmxlZIgBARI/ChhzZWNvbmRhcnlEaXNwbG'
+    'F5Q3VycmVuY3kYBSABKAlIAlIYc2Vjb25kYXJ5RGlzcGxheUN1cnJlbmN5iAEBQgsKCV9jdXJy'
+    'ZW5jeUIWChRfZHVhbEN1cnJlbmN5RW5hYmxlZEIbChlfc2Vjb25kYXJ5RGlzcGxheUN1cnJlbm'
+    'N5');
 
 @$core.Deprecated('Use deleteChainRequestDescriptor instead')
 const DeleteChainRequest$json = {

--- a/packages/protos/protos_weebi/lib/src/generated/firm.pb.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/firm.pb.dart
@@ -40,7 +40,7 @@ class Firm extends $pb.GeneratedMessage {
     $core.Map<$core.String, $core.String>? providerCustomerIds,
     $core.String? referralCode,
     $core.int? referralCreditBalanceCents,
-    $core.String? defaultCurrency,
+    $core.String? currency,
     $core.bool? dualCurrencyEnabled,
     $core.String? secondaryDisplayCurrency,
   }) {
@@ -100,8 +100,8 @@ class Firm extends $pb.GeneratedMessage {
     if (referralCreditBalanceCents != null) {
       result.referralCreditBalanceCents = referralCreditBalanceCents;
     }
-    if (defaultCurrency != null) {
-      result.defaultCurrency = defaultCurrency;
+    if (currency != null) {
+      result.currency = currency;
     }
     if (dualCurrencyEnabled != null) {
       result.dualCurrencyEnabled = dualCurrencyEnabled;
@@ -133,9 +133,9 @@ class Firm extends $pb.GeneratedMessage {
     ..m<$core.String, $core.String>(15, _omitFieldNames ? '' : 'providerCustomerIds', protoName: 'providerCustomerIds', entryClassName: 'Firm.ProviderCustomerIdsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('weebi.firm'))
     ..aOS(16, _omitFieldNames ? '' : 'referralCode', protoName: 'referralCode')
     ..a<$core.int>(17, _omitFieldNames ? '' : 'referralCreditBalanceCents', $pb.PbFieldType.O3, protoName: 'referralCreditBalanceCents')
-    ..aOS(18, _omitFieldNames ? '' : 'defaultCurrency')
-    ..aOB(19, _omitFieldNames ? '' : 'dualCurrencyEnabled')
-    ..aOS(20, _omitFieldNames ? '' : 'secondaryDisplayCurrency')
+    ..aOS(18, _omitFieldNames ? '' : 'currency')
+    ..aOB(19, _omitFieldNames ? '' : 'dualCurrencyEnabled', protoName: 'dualCurrencyEnabled')
+    ..aOS(20, _omitFieldNames ? '' : 'secondaryDisplayCurrency', protoName: 'secondaryDisplayCurrency')
     ..hasRequiredFields = false
   ;
 
@@ -339,15 +339,15 @@ class Firm extends $pb.GeneratedMessage {
 
   /// / ISO 4217 code (e.g. EUR, XOF). Default for new chains/boutiques; resolved with platform default if empty.
   @$pb.TagNumber(18)
-  $core.String get defaultCurrency => $_getSZ(17);
+  $core.String get currency => $_getSZ(17);
   @$pb.TagNumber(18)
-  set defaultCurrency($core.String v) { $_setString(17, v); }
+  set currency($core.String v) { $_setString(17, v); }
   @$pb.TagNumber(18)
-  $core.bool hasDefaultCurrency() => $_has(17);
+  $core.bool hasCurrency() => $_has(17);
   @$pb.TagNumber(18)
-  void clearDefaultCurrency() => clearField(18);
+  void clearCurrency() => clearField(18);
 
-  /// / When true, clients may show amounts in secondary_display_currency using per-ticket FX snapshot.
+  /// / When true, clients may show amounts in secondaryDisplayCurrency using per-ticket FX snapshot.
   @$pb.TagNumber(19)
   $core.bool get dualCurrencyEnabled => $_getBF(18);
   @$pb.TagNumber(19)
@@ -357,7 +357,7 @@ class Firm extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   void clearDualCurrencyEnabled() => clearField(19);
 
-  /// / ISO 4217 secondary display code (e.g. USD). Meaningful when dual_currency_enabled is true.
+  /// / ISO 4217 secondary display code (e.g. USD). Meaningful when dualCurrencyEnabled is true.
   @$pb.TagNumber(20)
   $core.String get secondaryDisplayCurrency => $_getSZ(19);
   @$pb.TagNumber(20)
@@ -371,14 +371,14 @@ class Firm extends $pb.GeneratedMessage {
 class CreateFirmRequest extends $pb.GeneratedMessage {
   factory CreateFirmRequest({
     $core.String? name,
-    $core.String? defaultCurrency,
+    $core.String? currency,
   }) {
     final result = create();
     if (name != null) {
       result.name = name;
     }
-    if (defaultCurrency != null) {
-      result.defaultCurrency = defaultCurrency;
+    if (currency != null) {
+      result.currency = currency;
     }
     return result;
   }
@@ -388,7 +388,7 @@ class CreateFirmRequest extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateFirmRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'weebi.firm'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
-    ..aOS(2, _omitFieldNames ? '' : 'defaultCurrency')
+    ..aOS(2, _omitFieldNames ? '' : 'currency')
     ..hasRequiredFields = false
   ;
 
@@ -425,13 +425,13 @@ class CreateFirmRequest extends $pb.GeneratedMessage {
 
   /// / Optional ISO 4217 default stamped on firm and first chain/boutique; server fills platform default if omitted.
   @$pb.TagNumber(2)
-  $core.String get defaultCurrency => $_getSZ(1);
+  $core.String get currency => $_getSZ(1);
   @$pb.TagNumber(2)
-  set defaultCurrency($core.String v) { $_setString(1, v); }
+  set currency($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
-  $core.bool hasDefaultCurrency() => $_has(1);
+  $core.bool hasCurrency() => $_has(1);
   @$pb.TagNumber(2)
-  void clearDefaultCurrency() => clearField(2);
+  void clearCurrency() => clearField(2);
 }
 
 class CreateFirmResponse extends $pb.GeneratedMessage {

--- a/packages/protos/protos_weebi/lib/src/generated/firm.pbjson.dart
+++ b/packages/protos/protos_weebi/lib/src/generated/firm.pbjson.dart
@@ -64,15 +64,15 @@ const Firm$json = {
     {'1': 'providerCustomerIds', '3': 15, '4': 3, '5': 11, '6': '.weebi.firm.Firm.ProviderCustomerIdsEntry', '10': 'providerCustomerIds'},
     {'1': 'referralCode', '3': 16, '4': 1, '5': 9, '10': 'referralCode'},
     {'1': 'referralCreditBalanceCents', '3': 17, '4': 1, '5': 5, '10': 'referralCreditBalanceCents'},
-    {'1': 'default_currency', '3': 18, '4': 1, '5': 9, '9': 0, '10': 'defaultCurrency', '17': true},
-    {'1': 'dual_currency_enabled', '3': 19, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
-    {'1': 'secondary_display_currency', '3': 20, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
+    {'1': 'currency', '3': 18, '4': 1, '5': 9, '9': 0, '10': 'currency', '17': true},
+    {'1': 'dualCurrencyEnabled', '3': 19, '4': 1, '5': 8, '9': 1, '10': 'dualCurrencyEnabled', '17': true},
+    {'1': 'secondaryDisplayCurrency', '3': 20, '4': 1, '5': 9, '9': 2, '10': 'secondaryDisplayCurrency', '17': true},
   ],
   '3': [Firm_ProviderCustomerIdsEntry$json],
   '8': [
-    {'1': '_default_currency'},
-    {'1': '_dual_currency_enabled'},
-    {'1': '_secondary_display_currency'},
+    {'1': '_currency'},
+    {'1': '_dualCurrencyEnabled'},
+    {'1': '_secondaryDisplayCurrency'},
   ],
 };
 
@@ -105,30 +105,30 @@ final $typed_data.Uint8List firmDescriptor = $convert.base64Decode(
     'Y2Vuc2UuTGljZW5zZVIIbGljZW5zZXMSWwoTcHJvdmlkZXJDdXN0b21lcklkcxgPIAMoCzIpLn'
     'dlZWJpLmZpcm0uRmlybS5Qcm92aWRlckN1c3RvbWVySWRzRW50cnlSE3Byb3ZpZGVyQ3VzdG9t'
     'ZXJJZHMSIgoMcmVmZXJyYWxDb2RlGBAgASgJUgxyZWZlcnJhbENvZGUSPgoacmVmZXJyYWxDcm'
-    'VkaXRCYWxhbmNlQ2VudHMYESABKAVSGnJlZmVycmFsQ3JlZGl0QmFsYW5jZUNlbnRzEi4KEGRl'
-    'ZmF1bHRfY3VycmVuY3kYEiABKAlIAFIPZGVmYXVsdEN1cnJlbmN5iAEBEjcKFWR1YWxfY3Vycm'
-    'VuY3lfZW5hYmxlZBgTIAEoCEgBUhNkdWFsQ3VycmVuY3lFbmFibGVkiAEBEkEKGnNlY29uZGFy'
-    'eV9kaXNwbGF5X2N1cnJlbmN5GBQgASgJSAJSGHNlY29uZGFyeURpc3BsYXlDdXJyZW5jeYgBAR'
-    'pGChhQcm92aWRlckN1c3RvbWVySWRzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUY'
-    'AiABKAlSBXZhbHVlOgI4AUITChFfZGVmYXVsdF9jdXJyZW5jeUIYChZfZHVhbF9jdXJyZW5jeV'
-    '9lbmFibGVkQh0KG19zZWNvbmRhcnlfZGlzcGxheV9jdXJyZW5jeQ==');
+    'VkaXRCYWxhbmNlQ2VudHMYESABKAVSGnJlZmVycmFsQ3JlZGl0QmFsYW5jZUNlbnRzEh8KCGN1'
+    'cnJlbmN5GBIgASgJSABSCGN1cnJlbmN5iAEBEjUKE2R1YWxDdXJyZW5jeUVuYWJsZWQYEyABKA'
+    'hIAVITZHVhbEN1cnJlbmN5RW5hYmxlZIgBARI/ChhzZWNvbmRhcnlEaXNwbGF5Q3VycmVuY3kY'
+    'FCABKAlIAlIYc2Vjb25kYXJ5RGlzcGxheUN1cnJlbmN5iAEBGkYKGFByb3ZpZGVyQ3VzdG9tZX'
+    'JJZHNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgBQgsK'
+    'CV9jdXJyZW5jeUIWChRfZHVhbEN1cnJlbmN5RW5hYmxlZEIbChlfc2Vjb25kYXJ5RGlzcGxheU'
+    'N1cnJlbmN5');
 
 @$core.Deprecated('Use createFirmRequestDescriptor instead')
 const CreateFirmRequest$json = {
   '1': 'CreateFirmRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    {'1': 'default_currency', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'defaultCurrency', '17': true},
+    {'1': 'currency', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'currency', '17': true},
   ],
   '8': [
-    {'1': '_default_currency'},
+    {'1': '_currency'},
   ],
 };
 
 /// Descriptor for `CreateFirmRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List createFirmRequestDescriptor = $convert.base64Decode(
-    'ChFDcmVhdGVGaXJtUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEi4KEGRlZmF1bHRfY3Vycm'
-    'VuY3kYAiABKAlIAFIPZGVmYXVsdEN1cnJlbmN5iAEBQhMKEV9kZWZhdWx0X2N1cnJlbmN5');
+    'ChFDcmVhdGVGaXJtUmVxdWVzdBISCgRuYW1lGAEgASgJUgRuYW1lEh8KCGN1cnJlbmN5GAIgAS'
+    'gJSABSCGN1cnJlbmN5iAEBQgsKCV9jdXJyZW5jeQ==');
 
 @$core.Deprecated('Use createFirmResponseDescriptor instead')
 const CreateFirmResponse$json = {

--- a/packages/protos/protos_weebi/pubspec.yaml
+++ b/packages/protos/protos_weebi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: protos_weebi
 description: protos for weebi
-version: 1.2.5
+version: 1.2.7
 repository: https://github.com/weebi-com/weebi_server/
 homepage: https://www.weebi.com
 


### PR DESCRIPTION
- Updated the protos version to 1.2.7 in the configuration files and changelogs.
- Enhanced `Boutique` and `Chain` protobuf definitions to include `dualCurrencyEnabled` and `secondaryDisplayCurrency` fields for improved currency management.
- Refactored related code to replace `defaultCurrency` with `currency` for consistency across the application.
- Updated documentation to reflect changes in currency handling and added relevant tests to ensure functionality.