### PR TITLE
chore: Bump protos version to 1.3.4 and update changelog

### DIFF
--- a/packages/protos/protos_weebi/CHANGELOG.md
+++ b/packages/protos/protos_weebi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.3.4 - 2026 may
+
+- simpler offer : entreprise or premium
+
 ## 1.3.3 - 2026 may
 
 - add retail total logic in ticket

--- a/packages/protos/protos_weebi/pubspec.yaml
+++ b/packages/protos/protos_weebi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: protos_weebi
 description: protos for weebi
-version: 1.3.3
+version: 1.3.4
 repository: https://github.com/weebi-com/weebi_server/
 homepage: https://www.weebi.com
 

--- a/packages/protos/protos_weebi/tool/generate_protos.sh
+++ b/packages/protos/protos_weebi/tool/generate_protos.sh
@@ -160,6 +160,7 @@ PROTO_FILES_TO_CHECK=(
   "common/chained_ids.proto"
   "common/g_common.proto"
   "common/g_timestamp.proto"
+  "common/options.proto"
   "common/phone.proto"
   "article/article.proto"
   "article/photo.proto"


### PR DESCRIPTION
- Updated the protos version to 1.3.4 in the configuration files.
- Added a new entry in the changelog for the simpler offer options: 'entreprise' and 'premium'.
- Included 'options.proto' in the list of files to check in the generate_protos script.