### PR TITLE
feat: enhance PawaPay integration with country-specific handling

### DIFF
--- a/doc/pawapay_integration.md
+++ b/doc/pawapay_integration.md
@@ -228,6 +228,8 @@ sequenceDiagram
 - Injectable `PawapayCheckoutClient` + `FakePawapayCheckoutClient` / `PawapayHttpCheckoutClient` (`MockClient` tests)
 - RPCs implemented: `createPawapayCheckout`, `fulfillLicenseFromPawapay`, `fulfillFromPawapayCheckout`
 - XOF list prices (v1): Premium **19000**, SYSCOHADA **1900** (aligned with marketing FCFA)
+- Country: firm → chain → boutique waterfall (alpha-2), converted to ISO-3 for PawaPay;
+  single `countries` / `amounts` entry (XOF/XAF only in v1)
 - Env: `PAWAPAY_API_BASE_URL`, `PAWAPAY_API_TOKEN`
 - Tests: `test/pawapay_checkout_test.dart`, `test/pawapay_billing_rpc_test.dart`
 

--- a/packages/billing_service/lib/billing_service.dart
+++ b/packages/billing_service/lib/billing_service.dart
@@ -6,3 +6,4 @@ library;
 export 'src/billing_service_base.dart';
 export 'src/accounting_year_purchase.dart';
 export 'src/pawapay_checkout.dart';
+export 'src/pawapay_country.dart';

--- a/packages/billing_service/lib/src/billing_service_base.dart
+++ b/packages/billing_service/lib/src/billing_service_base.dart
@@ -5,6 +5,7 @@ import 'package:fence_service/protos_weebi.dart';
 import 'package:fence_service/logging.dart';
 import 'package:billing_service/src/accounting_year_purchase.dart';
 import 'package:billing_service/src/pawapay_checkout.dart';
+import 'package:billing_service/src/pawapay_country.dart';
 import 'package:billing_service/src/stripe_checkout.dart';
 
 Set<String> _distinctNonEmptySeatUserIds(License license) {
@@ -1171,12 +1172,40 @@ class BillingService extends BillingServiceBase {
       return trimmed;
     });
 
+    final countryAlpha2 = await databaseMiddleware<String?>(_poolService, (db) async {
+      final firmDoc = await db
+          .collection(FenceService.firmCollectionName)
+          .findOne(where.eq('firmId', userPermission.firmId));
+      final chainDocs = await db
+          .collection(FenceService.boutiqueCollectionName)
+          .find(where.eq('firmId', userPermission.firmId))
+          .toList();
+      final preferredChainIds = userPermission.hasLimitedAccess()
+          ? userPermission.limitedAccess.chainIds.ids.toList()
+          : <String>[];
+      final preferredBoutiqueIds = userPermission.hasLimitedAccess()
+          ? userPermission.limitedAccess.boutiqueIds.ids.toList()
+          : <String>[];
+      return resolveOrgCountryAlpha2(
+        firmDoc: firmDoc,
+        chainDocs: chainDocs.map((e) => Map<String, dynamic>.from(e)),
+        preferredChainIds: preferredChainIds,
+        preferredBoutiqueIds: preferredBoutiqueIds,
+      );
+    });
+    if (countryAlpha2 == null || countryAlpha2.isEmpty) {
+      throw GrpcError.failedPrecondition(
+        'Set a boutique address country (ISO alpha-2) before paying with mobile money',
+      );
+    }
+
     final metaFields = <String, String>{
       'firmId': userPermission.firmId,
       'productId': product.productId,
       'productKind':
           isSyscohadaProductId(product.productId) ? 'syscohada' : 'license',
       'legalTermsVersionDate': request.legalTermsVersionDate.trim(),
+      'countryAlpha2': countryAlpha2,
     };
     if (isSyscohadaProductId(product.productId)) {
       metaFields['fiscalYear'] = request.fiscalYear.toString();
@@ -1191,9 +1220,12 @@ class BillingService extends BillingServiceBase {
       metaFields['purchaserEmail'] = purchaserEmail;
     }
 
-    List<PawapayAmount> amounts;
+    final PawapayAmount amount;
     try {
-      amounts = buildPawapayXofAmounts(product.productId);
+      amount = buildPawapayAmountForCountry(
+        productId: product.productId,
+        countryAlpha2Or3: countryAlpha2,
+      );
     } on ArgumentError catch (e) {
       throw GrpcError.failedPrecondition('${e.message}');
     }
@@ -1202,6 +1234,7 @@ class BillingService extends BillingServiceBase {
       'firmId': userPermission.firmId,
       'productId': product.productId,
       'checkoutId': checkoutId,
+      'country': amount.country,
     });
 
     try {
@@ -1210,8 +1243,8 @@ class BillingService extends BillingServiceBase {
       final created = await client.initiateCheckout(
         checkoutId: checkoutId,
         returnUrl: returnUrl,
-        amounts: amounts,
-        countries: kPawapayXofCountries,
+        amounts: [amount],
+        countries: [amount.country],
         metadata: buildPawapayMetadata(metaFields),
       );
       if (created.redirectUrl.isEmpty) {

--- a/packages/billing_service/lib/src/pawapay_checkout.dart
+++ b/packages/billing_service/lib/src/pawapay_checkout.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:billing_service/src/pawapay_country.dart';
 import 'package:http/http.dart' as http;
 
 /// Result of initiating a PawaPay hosted checkout.
@@ -241,17 +242,7 @@ String generateUuidV4() {
       '${h.substring(16, 20)}-${h.substring(20)}';
 }
 
-/// Sandbox / v1 XOF list prices aligned with marketing (FCFA).
-const kPawapayXofCountries = <String>[
-  'CIV',
-  'SEN',
-  'MLI',
-  'BFA',
-  'BEN',
-  'TGO',
-  'NER',
-];
-
+/// Marketing FCFA list prices (same numeric for XOF / XAF in v1).
 int pawapayXofAmountForProduct(String productId) {
   final id = productId.trim().toLowerCase();
   if (id == 'syscohada') return 1900;
@@ -260,11 +251,45 @@ int pawapayXofAmountForProduct(String productId) {
   throw ArgumentError.value(productId, 'productId', 'no XOF list price configured');
 }
 
-List<PawapayAmount> buildPawapayXofAmounts(String productId) {
+/// Builds a single-country PawaPay `amounts` entry from Weebi alpha-2 (or alpha-3).
+///
+/// Throws [ArgumentError] when the country cannot be mapped, currency is missing,
+/// or v1 pricing does not support that currency (non-FCFA).
+PawapayAmount buildPawapayAmountForCountry({
+  required String productId,
+  required String countryAlpha2Or3,
+}) {
+  final iso3 = iso2ToIso3Africa(countryAlpha2Or3);
+  if (iso3 == null) {
+    throw ArgumentError.value(
+      countryAlpha2Or3,
+      'country',
+      'unsupported country for PawaPay (need African ISO alpha-2)',
+    );
+  }
+  final currency = pawapayCurrencyForCountryIso3(iso3);
+  if (currency == null) {
+    throw ArgumentError.value(
+      iso3,
+      'country',
+      'no PawaPay currency mapping for country',
+    );
+  }
+  if (!kPawapayFcfaCurrencies.contains(currency)) {
+    throw ArgumentError.value(
+      iso3,
+      'country',
+      'PawaPay v1 licence checkout only supports XOF/XAF (got $currency)',
+    );
+  }
   final amount = pawapayXofAmountForProduct(productId).toString();
+  return PawapayAmount(country: iso3, currency: currency, amount: amount);
+}
+
+/// @Deprecated Use [buildPawapayAmountForCountry] with a single resolved country.
+List<PawapayAmount> buildPawapayXofAmounts(String productId) {
   return [
-    for (final c in kPawapayXofCountries)
-      PawapayAmount(country: c, currency: 'XOF', amount: amount),
+    buildPawapayAmountForCountry(productId: productId, countryAlpha2Or3: 'SN'),
   ];
 }
 

--- a/packages/billing_service/lib/src/pawapay_country.dart
+++ b/packages/billing_service/lib/src/pawapay_country.dart
@@ -1,0 +1,206 @@
+/// ISO 3166-1 alpha-2 → alpha-3 for PawaPay checkout `country` fields.
+///
+/// Weebi stores [Country.code2Letters] (alpha-2). PawaPay expects alpha-3.
+/// Focused on Africa, with OHADA / WAEMU / CEMAC members complete.
+const Map<String, String> kIso3166Alpha2ToAlpha3Africa = {
+  // OHADA / WAEMU (XOF)
+  'BJ': 'BEN',
+  'BF': 'BFA',
+  'CI': 'CIV',
+  'GW': 'GNB',
+  'ML': 'MLI',
+  'NE': 'NER',
+  'SN': 'SEN',
+  'TG': 'TGO',
+  // OHADA / CEMAC (XAF)
+  'CM': 'CMR',
+  'CF': 'CAF',
+  'TD': 'TCD',
+  'CG': 'COG',
+  'GQ': 'GNQ',
+  'GA': 'GAB',
+  // OHADA other
+  'GN': 'GIN',
+  'KM': 'COM',
+  'CD': 'COD',
+  // Broader Africa (common PawaPay corridors)
+  'AO': 'AGO',
+  'BW': 'BWA',
+  'CV': 'CPV',
+  'DJ': 'DJI',
+  'EG': 'EGY',
+  'ET': 'ETH',
+  'GH': 'GHA',
+  'KE': 'KEN',
+  'LR': 'LBR',
+  'LS': 'LSO',
+  'MG': 'MDG',
+  'MW': 'MWI',
+  'MA': 'MAR',
+  'MR': 'MRT',
+  'MU': 'MUS',
+  'MZ': 'MOZ',
+  'NA': 'NAM',
+  'NG': 'NGA',
+  'RW': 'RWA',
+  'ST': 'STP',
+  'SC': 'SYC',
+  'SL': 'SLE',
+  'SO': 'SOM',
+  'ZA': 'ZAF',
+  'SS': 'SSD',
+  'SD': 'SDN',
+  'TZ': 'TZA',
+  'UG': 'UGA',
+  'ZM': 'ZMB',
+  'ZW': 'ZWE',
+};
+
+/// ISO 4217 currencies we can price for v1 licence checkouts (FCFA list prices).
+const Set<String> kPawapayFcfaCurrencies = {'XOF', 'XAF'};
+
+/// PawaPay currency for an alpha-3 country code (OHADA FCFA + a few others).
+String? pawapayCurrencyForCountryIso3(String countryIso3) {
+  switch (countryIso3.trim().toUpperCase()) {
+    case 'BEN':
+    case 'BFA':
+    case 'CIV':
+    case 'GNB':
+    case 'MLI':
+    case 'NER':
+    case 'SEN':
+    case 'TGO':
+      return 'XOF';
+    case 'CMR':
+    case 'CAF':
+    case 'TCD':
+    case 'COG':
+    case 'GNQ':
+    case 'GAB':
+      return 'XAF';
+    case 'GIN':
+      return 'GNF';
+    case 'COM':
+      return 'KMF';
+    case 'COD':
+      return 'CDF';
+    case 'GHA':
+      return 'GHS';
+    case 'NGA':
+      return 'NGN';
+    case 'KEN':
+      return 'KES';
+    case 'RWA':
+      return 'RWF';
+    case 'UGA':
+      return 'UGX';
+    case 'TZA':
+      return 'TZS';
+    case 'ZMB':
+      return 'ZMW';
+    case 'MWI':
+      return 'MWK';
+    case 'MOZ':
+      return 'MZN';
+    case 'AGO':
+      return 'AOA';
+    case 'ZAF':
+      return 'ZAR';
+    case 'EGY':
+      return 'EGP';
+    case 'MAR':
+      return 'MAD';
+    default:
+      return null;
+  }
+}
+
+/// Converts Weebi alpha-2 to PawaPay alpha-3, or null if unknown / unsupported map.
+String? iso2ToIso3Africa(String? alpha2) {
+  final code = alpha2?.trim().toUpperCase() ?? '';
+  if (code.isEmpty) return null;
+  if (code.length == 3) {
+    // Already alpha-3 (or mistaken); accept if we know a currency for it.
+    return pawapayCurrencyForCountryIso3(code) != null ? code : null;
+  }
+  if (code.length != 2) return null;
+  return kIso3166Alpha2ToAlpha3Africa[code];
+}
+
+String? _alpha2FromCountryNode(dynamic country) {
+  if (country is! Map) return null;
+  final raw = country['code2Letters']?.toString().trim() ?? '';
+  if (raw.length == 2) return raw.toUpperCase();
+  return null;
+}
+
+String? _alpha2FromAddressFull(dynamic addressFull) {
+  if (addressFull is! Map) return null;
+  return _alpha2FromCountryNode(addressFull['country']);
+}
+
+/// Reads optional country on a firm/chain-shaped Mongo document.
+String? countryAlpha2FromOrgDoc(Map<String, dynamic>? doc) {
+  if (doc == null) return null;
+  return _alpha2FromCountryNode(doc['country']) ??
+      _alpha2FromAddressFull(doc['addressFull']);
+}
+
+/// BoutiqueMongo / nested boutique country (alpha-2).
+String? countryAlpha2FromBoutiqueMongo(Map<dynamic, dynamic>? boutiqueMongo) {
+  if (boutiqueMongo == null) return null;
+  final nested = boutiqueMongo['boutique'];
+  if (nested is Map) {
+    final fromNested = _alpha2FromAddressFull(nested['addressFull']);
+    if (fromNested != null) return fromNested;
+  }
+  return _alpha2FromAddressFull(boutiqueMongo['addressFull']);
+}
+
+int _preferIdRank(String? id, List<String> preferred) {
+  if (id == null || id.isEmpty || preferred.isEmpty) return 1;
+  return preferred.contains(id) ? 0 : 1;
+}
+
+/// Firm → chain → boutique waterfall (first non-empty alpha-2 wins).
+///
+/// Today only boutiques store [addressFull.country.code2Letters]; firm/chain
+/// country fields are read if present for forward compatibility.
+String? resolveOrgCountryAlpha2({
+  Map<String, dynamic>? firmDoc,
+  required Iterable<Map<String, dynamic>> chainDocs,
+  List<String> preferredChainIds = const [],
+  List<String> preferredBoutiqueIds = const [],
+}) {
+  final firmCountry = countryAlpha2FromOrgDoc(firmDoc);
+  if (firmCountry != null) return firmCountry;
+
+  final chains = chainDocs.toList();
+  chains.sort((a, b) {
+    final ra = _preferIdRank(a['chainId']?.toString(), preferredChainIds);
+    final rb = _preferIdRank(b['chainId']?.toString(), preferredChainIds);
+    return ra.compareTo(rb);
+  });
+
+  for (final chain in chains) {
+    final chainCountry = countryAlpha2FromOrgDoc(chain);
+    if (chainCountry != null) return chainCountry;
+
+    final boutiques = chain['boutiques'];
+    if (boutiques is! List) continue;
+    final btqs = boutiques.whereType<Map>().map((e) => Map<dynamic, dynamic>.from(e)).toList();
+    btqs.sort((a, b) {
+      final idA = a['boutiqueId']?.toString() ??
+          (a['boutique'] is Map ? (a['boutique'] as Map)['boutiqueId']?.toString() : null);
+      final idB = b['boutiqueId']?.toString() ??
+          (b['boutique'] is Map ? (b['boutique'] as Map)['boutiqueId']?.toString() : null);
+      return _preferIdRank(idA, preferredBoutiqueIds)
+          .compareTo(_preferIdRank(idB, preferredBoutiqueIds));
+    });
+    for (final b in btqs) {
+      final code = countryAlpha2FromBoutiqueMongo(b);
+      if (code != null) return code;
+    }
+  }
+  return null;
+}

--- a/packages/billing_service/test/pawapay_billing_rpc_test.dart
+++ b/packages/billing_service/test/pawapay_billing_rpc_test.dart
@@ -31,6 +31,28 @@ void main() {
       'licenses': <Map<String, dynamic>>[],
       'status': true,
     });
+    await db.collection(FenceService.boutiqueCollectionName).drop();
+    await db.createCollection(FenceService.boutiqueCollectionName);
+    await db.collection(FenceService.boutiqueCollectionName).insertOne({
+      'chainId': Dummy.chain.chainId,
+      'firmId': Dummy.firm.firmId,
+      'name': 'Test chain',
+      'boutiques': [
+        {
+          'boutiqueId': Dummy.boutiqueMongo.boutiqueId,
+          'firmId': Dummy.firm.firmId,
+          'chainId': Dummy.chain.chainId,
+          'boutique': {
+            'boutiqueId': Dummy.boutiqueMongo.boutiqueId,
+            'name': 'Dakar shop',
+            'addressFull': {
+              'city': 'Dakar',
+              'country': {'code2Letters': 'SN'},
+            },
+          },
+        },
+      ],
+    });
     await db.collection(FenceService.userCollectionName).insertOne({
       'userId': Dummy.adminPermission.userId,
       'mail': 'owner@weebi.test',
@@ -93,11 +115,19 @@ void main() {
     expect(resp.redirectUrl, isNotEmpty);
     expect(resp.checkoutId, isNotEmpty);
     expect(fakePawapay.initiated, hasLength(1));
-    final meta = fakePawapay.initiated.first['metadata'] as List;
+    final initiated = fakePawapay.initiated.first;
+    expect(initiated['countries'], ['SEN']);
+    final amounts = initiated['amounts'] as List;
+    expect(amounts, hasLength(1));
+    final amount = amounts.first as PawapayAmount;
+    expect(amount.country, 'SEN');
+    expect(amount.currency, 'XOF');
+    final meta = initiated['metadata'] as List;
     final flat = flattenPawapayMetadata(meta);
     expect(flat['firmId'], Dummy.firm.firmId);
     expect(flat['productId'], 'premium');
     expect(flat['purchaserEmail'], 'owner@weebi.test');
+    expect(flat['countryAlpha2'], 'SN');
   });
 
   test('fulfillFromPawapayCheckout creates PREMIUM licence idempotently', () async {

--- a/packages/billing_service/test/pawapay_checkout_test.dart
+++ b/packages/billing_service/test/pawapay_checkout_test.dart
@@ -74,8 +74,13 @@ void main() {
       final created = await client.initiateCheckout(
         checkoutId: 'afb57b93-7849-49aa-babb-4c3ccbfe3d79',
         returnUrl: 'https://app.weebi.com/#/billing?success=true',
-        amounts: buildPawapayXofAmounts('premium'),
-        countries: kPawapayXofCountries,
+        amounts: [
+          buildPawapayAmountForCountry(
+            productId: 'premium',
+            countryAlpha2Or3: 'SN',
+          ),
+        ],
+        countries: ['SEN'],
         metadata: buildPawapayMetadata({'firmId': 'firm-1', 'productId': 'premium'}),
       );
 
@@ -85,7 +90,10 @@ void main() {
       expect(captured.headers['Authorization'], 'Bearer tok_test');
       final body = jsonDecode(captured.body) as Map<String, dynamic>;
       expect(body['checkoutId'], 'afb57b93-7849-49aa-babb-4c3ccbfe3d79');
-      expect(body['countries'], contains('CIV'));
+      expect(body['countries'], ['SEN']);
+      expect(body['amounts'], [
+        {'country': 'SEN', 'currency': 'XOF', 'amount': '19000'},
+      ]);
     });
 
     test('fetchCheckout parses COMPLETED status + metadata', () async {
@@ -137,11 +145,127 @@ void main() {
         () => client.initiateCheckout(
           checkoutId: generateUuidV4(),
           returnUrl: 'https://x',
-          amounts: buildPawapayXofAmounts('premium'),
-          countries: kPawapayXofCountries,
+          amounts: [
+            buildPawapayAmountForCountry(
+              productId: 'premium',
+              countryAlpha2Or3: 'SN',
+            ),
+          ],
+          countries: ['SEN'],
           metadata: const [],
         ),
         throwsA(isA<PawapayCheckoutException>()),
+      );
+    });
+  });
+
+  group('iso2 / single country helpers', () {
+    test('maps OHADA alpha-2 to alpha-3 and XOF/XAF', () {
+      expect(iso2ToIso3Africa('sn'), 'SEN');
+      expect(iso2ToIso3Africa('CI'), 'CIV');
+      expect(iso2ToIso3Africa('cm'), 'CMR');
+      expect(pawapayCurrencyForCountryIso3('SEN'), 'XOF');
+      expect(pawapayCurrencyForCountryIso3('CMR'), 'XAF');
+    });
+
+    test('buildPawapayAmountForCountry is single country', () {
+      final a = buildPawapayAmountForCountry(
+        productId: 'syscohada',
+        countryAlpha2Or3: 'SN',
+      );
+      expect(a.country, 'SEN');
+      expect(a.currency, 'XOF');
+      expect(a.amount, '1900');
+    });
+
+    test('rejects non-FCFA African countries for v1 pricing', () {
+      expect(
+        () => buildPawapayAmountForCountry(
+          productId: 'premium',
+          countryAlpha2Or3: 'KE',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('resolveOrgCountryAlpha2 firm → chain → boutique', () {
+      expect(
+        resolveOrgCountryAlpha2(
+          firmDoc: {
+            'country': {'code2Letters': 'sn'},
+          },
+          chainDocs: const [],
+        ),
+        'SN',
+      );
+      expect(
+        resolveOrgCountryAlpha2(
+          firmDoc: {},
+          chainDocs: [
+            {
+              'chainId': 'c1',
+              'country': {'code2Letters': 'ci'},
+            },
+          ],
+        ),
+        'CI',
+      );
+      expect(
+        resolveOrgCountryAlpha2(
+          firmDoc: {},
+          chainDocs: [
+            {
+              'chainId': 'c1',
+              'boutiques': [
+                {
+                  'boutiqueId': 'b1',
+                  'boutique': {
+                    'addressFull': {
+                      'country': {'code2Letters': 'ml'},
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        ),
+        'ML',
+      );
+      expect(
+        resolveOrgCountryAlpha2(
+          firmDoc: {},
+          chainDocs: [
+            {
+              'chainId': 'other',
+              'boutiques': [
+                {
+                  'boutiqueId': 'bx',
+                  'boutique': {
+                    'addressFull': {
+                      'country': {'code2Letters': 'bf'},
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              'chainId': 'pref',
+              'boutiques': [
+                {
+                  'boutiqueId': 'wanted',
+                  'boutique': {
+                    'addressFull': {
+                      'country': {'code2Letters': 'sn'},
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          preferredChainIds: ['pref'],
+          preferredBoutiqueIds: ['wanted'],
+        ),
+        'SN',
       );
     });
   });


### PR DESCRIPTION
- Implemented country resolution logic for PawaPay checkout, converting firm, chain, and boutique addresses to ISO-3 format.
- Updated billing service to utilize a single `PawapayAmount` entry for checkout initiation based on the resolved country.
- Refactored related methods to support country-specific pricing and metadata.
- Added tests to validate country resolution and checkout functionality for various scenarios.