### PR TITLE
feat: Update protos version to 1.3.3 and enhance ticket data structures

### DIFF
--- a/apps/server/utils/create_indexes_views.dart
+++ b/apps/server/utils/create_indexes_views.dart
@@ -76,6 +76,8 @@ Future<void> main(List<String> args) async {
 
   /// WEB_SESSIONS - for web app session storage (cookie-based auth via Envoy)
   /// TTL index: MongoDB automatically deletes expired sessions
+  /// expiresAt is sliding-extended to 7 days (FenceService.webSessionTtl),
+  /// matching Envoy weebi_session_id Max-Age=604800.
   const webSessionsCollectionName = 'web_sessions';
   await db.createCollection(webSessionsCollectionName);
   await db.runCommand({

--- a/doc/entitlements.md
+++ b/doc/entitlements.md
@@ -2,16 +2,16 @@
 
 Two proofs drive most product gates. Keep this list updated when you add or remove checks.
 
-## 1. Firm creator operational joker (JWT)
+## 1. Firm creator operational access (JWT)
 
-- **Meaning:** The user who created the firm may use a **narrow preview path** for core sync without consuming a license seat.
-- **Implementation:** `UserPermissions.isFirmCreator` is honored only inside operational access — today [`assertUserHasOperationalLicense`](../../weebi_server/packages/fence_service/lib/src/operational_license_gate.dart) and its callers.
-- **Current RPC surfaces (joker OR active seat):**
+- **Meaning:** The user who created the firm may use a **narrow preview path** for core sync **without a license seat**. This is not a license. A creator may also hold a seat for other paid actions.
+- **Implementation:** [`assertUserHasOperationalLicense`](../../weebi_server/packages/fence_service/lib/src/operational_license_gate.dart) checks **creator first** (`userHasFirmCreatorOperationalAccess`: proto flag and/or JWT `isFirmCreator` / `is_firm_creator`), then, only if they are not the creator, an active seat.
+- **Current RPC surfaces (creator **or** active seat):**
   - `ticket_service`: create/read/update/delete tickets (`_assertOperationalLicense` in `ticket_service_base.dart`)
   - `article_service`: same pattern (`article_service_base.dart`)
   - `contact_service`: same pattern (`contact_service_base.dart`)
 
-The joker is **not** a blanket “admin can do everything” flag.
+Creator status is **not** a blanket “admin can do everything” flag.
 
 ## 2. License seat entitlement (`LicenseSeatEntitlement`)
 

--- a/packages/fence_service/lib/src/bearer_ext.dart
+++ b/packages/fence_service/lib/src/bearer_ext.dart
@@ -1,3 +1,4 @@
+import 'package:fence_service/src/entitlement_helpers.dart';
 import 'package:fence_service/src/jwt.dart';
 import 'package:protos_weebi/grpc.dart' show ServiceCall, GrpcError;
 import 'package:protos_weebi/protos_weebi_io.dart' show UserPermissions;
@@ -9,9 +10,15 @@ extension BearerExt on String {
       return UserPermissions.create();
     } else {
       try {
-        final d = JsonWebToken.parse(this).payload;
-        return UserPermissions.create()
-          ..mergeFromProto3Json(d, ignoreUnknownFields: true);
+        final payload =
+            JsonWebToken.parse(JsonWebToken.rawToken(this)).payload;
+        final permissions = UserPermissions.create()
+          ..mergeFromProto3Json(payload, ignoreUnknownFields: true);
+        // Proto3 JSON merge can drop is_firm_creator / nested claims.
+        if (jwtPayloadSaysFirmCreator(payload)) {
+          permissions.isFirmCreator = true;
+        }
+        return permissions;
       } on FormatException catch (e) {
         print('BearerExt userPermissions $e');
         rethrow;

--- a/packages/fence_service/lib/src/entitlement_helpers.dart
+++ b/packages/fence_service/lib/src/entitlement_helpers.dart
@@ -2,19 +2,42 @@ import 'package:fence_service/protos_weebi.dart';
 
 import 'license_seat_entitlement.dart';
 
-/// Whether the bearer qualifies for the **firm creator operational joker**:
-/// preview sync for ticket / article / contact RPCs without a license seat.
+/// Whether the proto already carries [UserPermissions.isFirmCreator].
 ///
-/// Use **only** together with [assertUserHasOperationalLicense]-style checks.
-/// Seat-gated product features must use [userHasActiveLicensedSeat] instead
-/// (no joker).
+/// Prefer [userHasFirmCreatorOperationalAccess] on the operational path so a
+/// JWT claim still counts if proto3 JSON merge dropped the field.
 bool firmCreatorOperationalJoker(UserPermissions userPermissions) =>
     userPermissions.isFirmCreator;
+
+/// Firm-creator claim on a JWT payload (root, snake_case, or nested
+/// `permissions`). Independent of license seats.
+bool jwtPayloadSaysFirmCreator(Map<String, dynamic>? payload) {
+  if (payload == null) return false;
+  bool isTrue(dynamic v) => v == true;
+  if (isTrue(payload['isFirmCreator']) || isTrue(payload['is_firm_creator'])) {
+    return true;
+  }
+  final nested = payload['permissions'];
+  if (nested is Map) {
+    return isTrue(nested['isFirmCreator']) || isTrue(nested['is_firm_creator']);
+  }
+  return false;
+}
+
+/// Operational sync access as **firm creator** — not a license.
+///
+/// Proto flag **or** raw JWT claim. Seat-gated product features must still
+/// use [userHasActiveLicensedSeat] (no creator exemption).
+bool userHasFirmCreatorOperationalAccess({
+  required UserPermissions userPermissions,
+  Map<String, dynamic>? jwtPayload,
+}) =>
+    userPermissions.isFirmCreator || jwtPayloadSaysFirmCreator(jwtPayload);
 
 /// Active seat on a valid firm license — for subscription-backed features.
 ///
 /// Mirrors [LicenseSeatEntitlement.userHasActiveLicensedSeat] with a name that
-/// contrasts with [firmCreatorOperationalJoker].
+/// contrasts with [userHasFirmCreatorOperationalAccess].
 bool userHasActiveLicensedSeat(
   String userId,
   Iterable<License> licenses, {

--- a/packages/fence_service/lib/src/jwt.dart
+++ b/packages/fence_service/lib/src/jwt.dart
@@ -117,6 +117,15 @@ class JsonWebToken {
 
   Map<String, dynamic> get payload => _payload;
 
+  /// Bare JWT from `Authorization` (`Bearer <jwt>` or the token alone).
+  static String rawToken(String authorizationHeader) {
+    final t = authorizationHeader.trim();
+    if (t.startsWith('Bearer ')) {
+      return t.substring(7).trim();
+    }
+    return t;
+  }
+
   /// Whether this token is from a service account (e.g. weebi_express calling
   /// FulfillLicenseFromStripe). Uses a strict rule: both conditions required.
   /// - [tags] (in payload) must contain "service_account". Tags are not in

--- a/packages/fence_service/lib/src/operational_license_gate.dart
+++ b/packages/fence_service/lib/src/operational_license_gate.dart
@@ -32,10 +32,13 @@ Future<List<License>> loadFirmLicenses(Db db, String firmId) async {
 
 /// Throws [GrpcError.failedPrecondition] if the user may not use ticket/article/contact flows.
 ///
-/// **Firm creator operational joker:** [UserPermissions.isFirmCreator] bypasses the
-/// seat check here only — a narrow preview/sync path. Subscription-backed product
-/// features (e.g. portal ticket store filter/group) must use [userHasActiveLicensedSeat]
-/// without this bypass (see `entitlement_helpers.dart`, webapp `SeatCapability`).
+/// Two **independent** predicates (firm creator is not a license):
+/// 1. Firm creator — [userHasFirmCreatorOperationalAccess] (proto and/or JWT claim).
+///    Allows this sync path only. Does not grant seat-gated product features.
+/// 2. Else an [userHasActiveLicensedSeat] on [licenses].
+///
+/// Subscription-backed features (e.g. portal ticket store filter/group, business
+/// rules) must use [userHasActiveLicensedSeat] with **no** creator exemption.
 ///
 /// No-op when [UserPermissions.firmId] is empty, or the bearer is a service-account JWT.
 ///
@@ -49,15 +52,15 @@ void assertUserHasOperationalLicense({
 
   if (userPermissions.firmId.isEmpty) return;
 
-  var token = authorizationHeader.trim();
-  if (token.startsWith('Bearer ')) {
-    token = token.substring(7).trim();
-  }
-  if (token.isNotEmpty) {
+  Map<String, dynamic>? jwtPayload;
+  final rawToken = JsonWebToken.rawToken(authorizationHeader);
+  if (rawToken.isNotEmpty) {
     try {
-      if (JsonWebToken.parse(token).isServiceAccount) return;
+      final jwt = JsonWebToken.parse(rawToken);
+      jwtPayload = jwt.payload;
+      if (jwt.isServiceAccount) return;
     } on FormatException {
-      // Still enforce normal license path if token shape is wrong.
+      // Still enforce the two predicates if token shape is wrong.
     }
   }
 
@@ -67,8 +70,15 @@ void assertUserHasOperationalLicense({
     );
   }
 
-  if (firmCreatorOperationalJoker(userPermissions)) return;
+  // 1. Creator — do not consult seats.
+  if (userHasFirmCreatorOperationalAccess(
+    userPermissions: userPermissions,
+    jwtPayload: jwtPayload,
+  )) {
+    return;
+  }
 
+  // 2. Non-creator — require a seat.
   if (userHasActiveLicensedSeat(userPermissions.userId, licenses)) {
     return;
   }

--- a/packages/fence_service/test/operational_license_gate_mongo_test.dart
+++ b/packages/fence_service/test/operational_license_gate_mongo_test.dart
@@ -132,6 +132,30 @@ void main() {
       }
     });
 
+    test('firm creator allowed when DB firm has empty licenses', () async {
+      final db = await pool.acquire();
+      const id = 'gate_db_creator_empty_lic';
+      final coll = db.collection(FenceService.firmCollectionName);
+      try {
+        await coll.deleteMany(where.eq('firmId', id));
+        await coll.insertOne({
+          'firmId': id,
+          'licenses': <dynamic>[],
+        });
+        await assertUserHasOperationalLicenseWithDb(
+          db,
+          userPermissions: UserPermissions.create()
+            ..firmId = id
+            ..userId = 'u-creator'
+            ..isFirmCreator = true,
+          authorizationHeader: '',
+        );
+      } finally {
+        await coll.deleteMany(where.eq('firmId', id));
+        pool.release(db);
+      }
+    });
+
     test('non-creator allowed when seat is persisted on firm', () async {
       final db = await pool.acquire();
       const id = 'gate_db_seated';

--- a/packages/fence_service/test/operational_license_gate_test.dart
+++ b/packages/fence_service/test/operational_license_gate_test.dart
@@ -322,6 +322,78 @@ void main() {
       );
     });
 
+    test('allows creator with a seat (creator and seat are independent)', () {
+      assertUserHasOperationalLicense(
+        userPermissions: UserPermissions.create()
+          ..firmId = 'f'
+          ..userId = 'u1'
+          ..isFirmCreator = true,
+        authorizationHeader: '',
+        licenses: [licenseWithSeat('u1')],
+      );
+    });
+
+    test('allows creator from JWT isFirmCreator when proto flag is false', () {
+      assertUserHasOperationalLicense(
+        userPermissions: UserPermissions.create()
+          ..firmId = 'f'
+          ..userId = 'u1',
+        authorizationHeader: _unsignedJwt({'isFirmCreator': true}),
+        licenses: [],
+      );
+    });
+
+    test('allows creator from JWT is_firm_creator when proto flag is false',
+        () {
+      assertUserHasOperationalLicense(
+        userPermissions: UserPermissions.create()
+          ..firmId = 'f'
+          ..userId = 'u1',
+        authorizationHeader: _unsignedJwt({'is_firm_creator': true}),
+        licenses: [],
+      );
+    });
+
+    test('allows creator from nested JWT permissions.isFirmCreator', () {
+      assertUserHasOperationalLicense(
+        userPermissions: UserPermissions.create()
+          ..firmId = 'f'
+          ..userId = 'u1',
+        authorizationHeader: _unsignedJwt({
+          'permissions': {'isFirmCreator': true},
+        }),
+        licenses: [],
+      );
+    });
+
+    test('Bearer prefix still sees JWT firm-creator claim', () {
+      final token = _unsignedJwt({'isFirmCreator': true});
+      assertUserHasOperationalLicense(
+        userPermissions: UserPermissions.create()
+          ..firmId = 'f'
+          ..userId = 'u1',
+        authorizationHeader: 'Bearer $token',
+        licenses: [],
+      );
+    });
+
+    test('minted proto JWT round-trips isFirmCreator via BearerExt', () {
+      final minted = UserPermissions.create()
+        ..firmId = 'f'
+        ..userId = 'u1'
+        ..isFirmCreator = true;
+      final token = _unsignedJwt(
+        minted.toProto3Json() as Map<String, dynamic>,
+      );
+      final parsed = token.userPermissions;
+      expect(parsed.isFirmCreator, isTrue);
+      assertUserHasOperationalLicense(
+        userPermissions: parsed,
+        authorizationHeader: token,
+        licenses: [],
+      );
+    });
+
     test('allows non-creator with active seat', () {
       assertUserHasOperationalLicense(
         userPermissions: UserPermissions.create()
@@ -525,6 +597,44 @@ void main() {
       );
       expect(
         firmCreatorOperationalJoker(UserPermissions.create()),
+        isFalse,
+      );
+    });
+
+    test('jwtPayloadSaysFirmCreator reads root, snake_case, nested', () {
+      expect(jwtPayloadSaysFirmCreator({'isFirmCreator': true}), isTrue);
+      expect(jwtPayloadSaysFirmCreator({'is_firm_creator': true}), isTrue);
+      expect(
+        jwtPayloadSaysFirmCreator({
+          'permissions': {'isFirmCreator': true},
+        }),
+        isTrue,
+      );
+      expect(jwtPayloadSaysFirmCreator({'isFirmCreator': false}), isFalse);
+      expect(jwtPayloadSaysFirmCreator({}), isFalse);
+      expect(jwtPayloadSaysFirmCreator(null), isFalse);
+    });
+
+    test('userHasFirmCreatorOperationalAccess is proto OR jwt', () {
+      expect(
+        userHasFirmCreatorOperationalAccess(
+          userPermissions: UserPermissions.create()..isFirmCreator = true,
+          jwtPayload: null,
+        ),
+        isTrue,
+      );
+      expect(
+        userHasFirmCreatorOperationalAccess(
+          userPermissions: UserPermissions.create(),
+          jwtPayload: {'isFirmCreator': true},
+        ),
+        isTrue,
+      );
+      expect(
+        userHasFirmCreatorOperationalAccess(
+          userPermissions: UserPermissions.create(),
+          jwtPayload: {},
+        ),
         isFalse,
       );
     });

--- a/packages/fence_service/test/web_session_test.dart
+++ b/packages/fence_service/test/web_session_test.dart
@@ -1,6 +1,5 @@
 import 'package:fence_service/fence_service.dart';
 import 'package:fence_service/grpc.dart';
-import 'package:fence_service/mongo_dart.dart';
 import 'package:fence_service/mongo_local_testing.dart';
 import 'package:fence_service/mongo_pool.dart';
 import 'package:protos_weebi/data_dummy.dart';


### PR DESCRIPTION
- Bumped the protos version to 1.3.3 in the configuration files.
- Added new data structures for ticket sell and spend totals in the generated protos, improving the handling of ticket financial data.
- Introduced a method to revoke all web sessions for a user, enhancing security during password updates.
- Updated changelog to reflect new features and changes.